### PR TITLE
HACK: disable UHS mode on all MMC controlers

### DIFF
--- a/include/linux/mmc/host.h
+++ b/include/linux/mmc/host.h
@@ -490,9 +490,7 @@ static inline int mmc_boot_partition_access(struct mmc_host *host)
 static inline int mmc_host_uhs(struct mmc_host *host)
 {
 	return host->caps &
-		(MMC_CAP_UHS_SDR12 | MMC_CAP_UHS_SDR25 |
-		 MMC_CAP_UHS_SDR50 | MMC_CAP_UHS_SDR104 |
-		 MMC_CAP_UHS_DDR50);
+		0;
 }
 
 static inline int mmc_host_packed_wr(struct mmc_host *host)


### PR DESCRIPTION
This clear hack is needed for RCAR boards, where SDHCI causes
problems, when it works in UHS (Ultra High Speed) mode.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>