### PR TITLE
Revert "HACK: disable UHS mode on all MMC controlers"

### DIFF
--- a/include/linux/mmc/host.h
+++ b/include/linux/mmc/host.h
@@ -490,7 +490,9 @@ static inline int mmc_boot_partition_access(struct mmc_host *host)
 static inline int mmc_host_uhs(struct mmc_host *host)
 {
 	return host->caps &
-		0;
+		(MMC_CAP_UHS_SDR12 | MMC_CAP_UHS_SDR25 |
+		 MMC_CAP_UHS_SDR50 | MMC_CAP_UHS_SDR104 |
+		 MMC_CAP_UHS_DDR50);
 }
 
 static inline int mmc_host_packed_wr(struct mmc_host *host)


### PR DESCRIPTION
This reverts commit fd532f419548da75f3e297cd54bec8889d763870.

Seems, that this patch fixed board-specific issue, while introducing
huge performance penalties on Android guest.