### PR TITLE
[HACK?]rcar_du_vs: zero-out sg_tables on plane duplication

### DIFF
--- a/drivers/gpu/drm/rcar-du/rcar_du_vsp.c
+++ b/drivers/gpu/drm/rcar-du/rcar_du_vsp.c
@@ -369,6 +369,8 @@ rcar_du_vsp_plane_atomic_duplicate_state(struct drm_plane *plane)
 	if (copy == NULL)
 		return NULL;
 
+	memset(state->sg_tables, 0, sizeof(state->sg_tables));
+
 	__drm_atomic_helper_plane_duplicate_state(plane, &copy->state);
 
 	return &copy->state;


### PR DESCRIPTION
Zero-out sg_tables in original plane, efectively introducing move
semantic. Seems, this fixes issue with double-free,
when rcar_du_vsp_plane_cleanup_fb() freed the same sg_table
both in original plane and in the copy.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>