### PR TITLE
clk:shmobile: Hide clock for SCIF2

### DIFF
--- a/drivers/clk/renesas/r8a77965-cpg-mssr.c
+++ b/drivers/clk/renesas/r8a77965-cpg-mssr.c
@@ -135,7 +135,7 @@ static const struct mssr_mod_clk r8a77965_mod_clks[] __initconst = {
 	DEF_MOD("cmt2",			 301,	R8A77965_CLK_R),
 	DEF_MOD("cmt1",			 302,	R8A77965_CLK_R),
 	DEF_MOD("cmt0",			 303,	R8A77965_CLK_R),
-	DEF_MOD("scif2",		 310,	R8A77965_CLK_S3D4),
+	/*DEF_MOD("scif2",		 310,	R8A77965_CLK_S3D4),*/
 	DEF_MOD("sdif3",		 311,	R8A77965_CLK_SD3),
 	DEF_MOD("sdif2",		 312,	R8A77965_CLK_SD2),
 	DEF_MOD("sdif1",		 313,	R8A77965_CLK_SD1),


### PR DESCRIPTION
This is follow up patch for a89a28cd7ac637baca6b6df42b361165dedc9865

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>