### PR TITLE
rcar-fcp: Add FCPVD reset sequence for VSPD

### DIFF
--- a/drivers/media/platform/vsp1/vsp1_pipe.c
+++ b/drivers/media/platform/vsp1/vsp1_pipe.c
@@ -17,6 +17,7 @@
 #include <linux/wait.h>
 
 #include <media/media-entity.h>
+#include <media/rcar-fcp.h>
 #include <media/v4l2-subdev.h>
 
 #include "vsp1.h"
@@ -287,6 +288,11 @@ int vsp1_pipeline_stop(struct vsp1_pipeline *pipe)
 			pipe->state = VSP1_PIPELINE_STOPPED;
 			spin_unlock_irqrestore(&pipe->irqlock, flags);
 		}
+
+		if ((vsp1->version & VI6_IP_VERSION_MODEL_MASK) ==
+		    VI6_IP_VERSION_MODEL_VSPD_GEN3)
+			ret = rcar_fcp_reset(vsp1->fcp);
+
 	} else {
 		/* Otherwise just request a stop and wait. */
 		spin_lock_irqsave(&pipe->irqlock, flags);

--- a/include/media/rcar-fcp.h
+++ b/include/media/rcar-fcp.h
@@ -22,6 +22,7 @@ void rcar_fcp_put(struct rcar_fcp_device *fcp);
 struct device *rcar_fcp_get_device(struct rcar_fcp_device *fcp);
 int rcar_fcp_enable(struct rcar_fcp_device *fcp);
 void rcar_fcp_disable(struct rcar_fcp_device *fcp);
+int rcar_fcp_reset(struct rcar_fcp_device *fcp);
 #else
 static inline struct rcar_fcp_device *rcar_fcp_get(const struct device_node *np)
 {
@@ -37,6 +38,10 @@ static inline int rcar_fcp_enable(struct rcar_fcp_device *fcp)
 	return 0;
 }
 static inline void rcar_fcp_disable(struct rcar_fcp_device *fcp) { }
+static inline int rcar_fcp_reset(struct rcar_fcp_device *fcp)
+{
+	return 0;
+}
 #endif
 
 #endif /* __MEDIA_RCAR_FCP_H__ */


### PR DESCRIPTION
According to H/W manual v1.00, VSPD must be excecuted
FCP_RST.SOFTRST after VI6_SRESET.SRST. So this patch adds it.
VSPDL is not applicable.

Signed-off-by: Koji Matsuoka <koji.matsuoka.xm@renesas.com>