### PR TITLE
Dma fixes

### DIFF
--- a/drivers/dma/sh/rcar-dmac.c
+++ b/drivers/dma/sh/rcar-dmac.c
@@ -774,8 +774,9 @@ static void rcar_dmac_sync_tcr(struct rcar_dmac_chan *chan)
 	/* make sure all remaining data was flushed */
 	rcar_dmac_chcr_de_barrier(chan);
 
-	/* back DE */
-	rcar_dmac_chan_write(chan, RCAR_DMACHCR, chcr);
+	/* back DE if remain data exists */
+	if (rcar_dmac_chan_read(chan, RCAR_DMATCR))
+		rcar_dmac_chan_write(chan, RCAR_DMACHCR, chcr);
 }
 
 static void rcar_dmac_chan_halt(struct rcar_dmac_chan *chan)

--- a/drivers/dma/sh/rcar-dmac.c
+++ b/drivers/dma/sh/rcar-dmac.c
@@ -761,6 +761,17 @@ static void rcar_dmac_chcr_de_barrier(struct rcar_dmac_chan *chan)
 	dev_err(chan->chan.device->dev, "CHCR DE check error\n");
 }
 
+static void rcar_dmac_clear_chcr_de(struct rcar_dmac_chan *chan)
+{
+	u32 chcr = rcar_dmac_chan_read(chan, RCAR_DMACHCR);
+
+	/* set DE=0 and flush remaining data */
+	rcar_dmac_chan_write(chan, RCAR_DMACHCR, (chcr & ~RCAR_DMACHCR_DE));
+
+	/* make sure all remaining data was flushed */
+	rcar_dmac_chcr_de_barrier(chan);
+}
+
 static void rcar_dmac_sync_tcr(struct rcar_dmac_chan *chan)
 {
 	u32 chcr = rcar_dmac_chan_read(chan, RCAR_DMACHCR);
@@ -768,11 +779,7 @@ static void rcar_dmac_sync_tcr(struct rcar_dmac_chan *chan)
 	if (!(chcr & RCAR_DMACHCR_DE))
 		return;
 
-	/* set DE=0 and flush remaining data */
-	rcar_dmac_chan_write(chan, RCAR_DMACHCR, (chcr & ~RCAR_DMACHCR_DE));
-
-	/* make sure all remaining data was flushed */
-	rcar_dmac_chcr_de_barrier(chan);
+	rcar_dmac_clear_chcr_de(chan);
 
 	/* back DE if remain data exists */
 	if (rcar_dmac_chan_read(chan, RCAR_DMATCR))

--- a/drivers/dma/sh/rcar-dmac.c
+++ b/drivers/dma/sh/rcar-dmac.c
@@ -1273,6 +1273,18 @@ static int rcar_dmac_device_config(struct dma_chan *chan,
 	return 0;
 }
 
+static int rcar_dmac_chan_pause(struct dma_chan *chan)
+{
+	unsigned long flags;
+	struct rcar_dmac_chan *rchan = to_rcar_dmac_chan(chan);
+
+	spin_lock_irqsave(&rchan->lock, flags);
+	rcar_dmac_clear_chcr_de(rchan);
+	spin_unlock_irqrestore(&rchan->lock, flags);
+
+	return 0;
+}
+
 static int rcar_dmac_chan_terminate_all(struct dma_chan *chan)
 {
 	struct rcar_dmac_chan *rchan = to_rcar_dmac_chan(chan);
@@ -1890,6 +1902,7 @@ static int rcar_dmac_probe(struct platform_device *pdev)
 	engine->device_prep_slave_sg		= rcar_dmac_prep_slave_sg;
 	engine->device_prep_dma_cyclic		= rcar_dmac_prep_dma_cyclic;
 	engine->device_config			= rcar_dmac_device_config;
+	engine->device_pause			= rcar_dmac_chan_pause;
 	engine->device_terminate_all		= rcar_dmac_chan_terminate_all;
 	engine->device_tx_status		= rcar_dmac_tx_status;
 	engine->device_issue_pending		= rcar_dmac_issue_pending;

--- a/drivers/dma/sh/rcar-dmac.c
+++ b/drivers/dma/sh/rcar-dmac.c
@@ -772,20 +772,6 @@ static void rcar_dmac_clear_chcr_de(struct rcar_dmac_chan *chan)
 	rcar_dmac_chcr_de_barrier(chan);
 }
 
-static void rcar_dmac_sync_tcr(struct rcar_dmac_chan *chan)
-{
-	u32 chcr = rcar_dmac_chan_read(chan, RCAR_DMACHCR);
-
-	if (!(chcr & RCAR_DMACHCR_DE))
-		return;
-
-	rcar_dmac_clear_chcr_de(chan);
-
-	/* back DE if remain data exists */
-	if (rcar_dmac_chan_read(chan, RCAR_DMATCR))
-		rcar_dmac_chan_write(chan, RCAR_DMACHCR, chcr);
-}
-
 static void rcar_dmac_chan_halt(struct rcar_dmac_chan *chan)
 {
 	u32 chcr = rcar_dmac_chan_read(chan, RCAR_DMACHCR);
@@ -1384,9 +1370,6 @@ static unsigned int rcar_dmac_chan_get_residue(struct rcar_dmac_chan *chan,
 
 		residue += chunk->size;
 	}
-
-	if (desc->direction == DMA_DEV_TO_MEM)
-		rcar_dmac_sync_tcr(chan);
 
 	/* Add the residue for the current chunk. */
 	residue += rcar_dmac_chan_read(chan, RCAR_DMATCRB) << desc->xfer_shift;


### PR DESCRIPTION
Actually, the first patch (a39daa2) is a direct fix for the "memory corruption issue" triggered by audio record use-case (dma dev-to-mem transaction). But, it was agreed to take a few additional patches according to their descriptions. So, with these patches applied the "issue" is not observed anymore.