### PR TITLE
Fix kernel configuration for Xen coord driver

### DIFF
--- a/drivers/xen/Kconfig
+++ b/drivers/xen/Kconfig
@@ -335,7 +335,7 @@ config XEN_HAVE_VPMU
        bool
 
 config XEN_COORD_SUSPEND
-    bool
+    def_bool y
     depends on (ARM || ARM64) && SUSPEND
     help
         Enables support for handling of coordinated suspend interrupts. Allows


### PR DESCRIPTION
The way Kconfig is written kernel doesn't enable the
Xen coordinated suspend driver when all the prerequisites
are satisfied.

Fixes: 81197697eead ("zynqmp: New platform driver for Xen coordinated suspend")

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>