### PR TITLE
HACK: Rename ion_system_heap to rcar-ion

### DIFF
--- a/drivers/staging/android/ion/ion_system_heap.c
+++ b/drivers/staging/android/ion/ion_system_heap.c
@@ -353,7 +353,7 @@ static int ion_system_heap_create(void)
 	heap = __ion_system_heap_create();
 	if (IS_ERR(heap))
 		return PTR_ERR(heap);
-	heap->name = "ion_system_heap";
+	heap->name = "rcar-ion";
 
 	ion_device_add_heap(heap);
 	return 0;


### PR DESCRIPTION
This HACK is needed only to comply with some internal
naming in ddk um.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>