### PR TITLE
M3N fix

### DIFF
--- a/drivers/soc/renesas/rcar-sysc.c
+++ b/drivers/soc/renesas/rcar-sysc.c
@@ -97,6 +97,12 @@ const struct soc_device_attribute rcar_sysc_quirks_match[] __initconst = {
 			| BIT(R8A7796_PD_A3IR) | BIT(R8A7796_PD_3DG_A)
 			| BIT(R8A7796_PD_3DG_B)),
 	},
+	{
+		.soc_id = "r8a77965", .revision = "ES1.0",
+		.data = (void *)(BIT(R8A77965_PD_A3VP) | BIT(R8A77965_PD_CR7)
+			| BIT(R8A77965_PD_A3VC) | BIT(R8A77965_PD_A2VC1)
+			| BIT(R8A77965_PD_A3IR)),
+	},
 	{ /* sentinel */ }
 };
 


### PR DESCRIPTION
The purpose is the same as for the following patch:
0399140 [HACK?]soc: Extend always on logic to H3 ES3.0

Some Cache IPMMUs are located in non-always-on power domains
(IPMMU-VPx, IPMMU-VCx, etc belong to A3xx domains), so mark these
domains appropriately for the system won't be able to turn them off.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>