### PR TITLE
xen-blkfront: Do not init if virtio-disk is used

### DIFF
--- a/drivers/block/xen-blkfront.c
+++ b/drivers/block/xen-blkfront.c
@@ -1938,6 +1938,12 @@ static int blkfront_probe(struct xenbus_device *dev,
 	int err, vdevice;
 	struct blkfront_info *info;
 
+	if (xenbus_exists(XBT_NIL, "device/virtio_disk", "")) {
+		printk(KERN_INFO "%s: Skip probe for device %s (virtio is used)\n",
+				__func__, id);
+		return -1;
+	}
+
 	/* FIXME: Use dynamic device id if this is not set. */
 	err = xenbus_scanf(XBT_NIL, dev->nodename,
 			   "virtual-device", "%i", &vdevice);


### PR DESCRIPTION
This needed for using the same kernel image (without a need to rebuild)
for both the virtio and Xen PV involved frontends.

This way we don't need to disable CONFIG_XEN_BLKDEV_FRONTEND
if we want to run Android on virtio block device.

Please note this a temp solution which should go away once we
switch Android to use virtio block device by default.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>