### PR TITLE
optee: remove address tag in check_mem_type()

### DIFF
--- a/drivers/tee/optee/call.c
+++ b/drivers/tee/optee/call.c
@@ -567,6 +567,8 @@ static int check_mem_type(unsigned long start, size_t num_pages)
 	struct mm_struct *mm = current->mm;
 	int rc;
 
+	start = untagged_addr(start);
+
 	down_read(&mm->mmap_sem);
 	rc = __check_mem_type(find_vma(mm, start),
 			      start + num_pages * PAGE_SIZE);


### PR DESCRIPTION
Before passing 'start' to find_vma() we need to remove
tags from it to get sane results.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>