### PR TITLE
zynqmp: dts: Remove old IOMMU bindings from SMMUv2 node

### DIFF
--- a/arch/arm64/boot/dts/xilinx/xen-overlay.dtsi
+++ b/arch/arm64/boot/dts/xilinx/xen-overlay.dtsi
@@ -28,11 +28,6 @@
 
 &smmu {
 	status = "okay";
-	mmu-masters = < &gem0 0x874
-			&gem1 0x875
-			&gem2 0x876
-			&gem3 0x877
-			&pcie 0x4d0>;
 };
 
 &gem0 {


### PR DESCRIPTION
Xen now supports new IOMMU bindings, so this leads to mix of old and new
ones, so remove the old bindings to fix that.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>