### PR TITLE
dom0: Set Domain-0 memory to 512M

### DIFF
--- a/arch/arm64/boot/dts/xilinx/xen-overlay.dtsi
+++ b/arch/arm64/boot/dts/xilinx/xen-overlay.dtsi
@@ -3,7 +3,7 @@
 		#address-cells = <2>;
 		#size-cells = <1>;
 
-		xen,xen-bootargs = "console=dtuart dtuart=serial0 dom0_mem=1256M bootscrub=0 maxcpus=1 timer_slop=0 pci=on";
+		xen,xen-bootargs = "console=dtuart dtuart=serial0 dom0_mem=512M bootscrub=0 maxcpus=1 timer_slop=0 pci=on";
 		xen,dom0-bootargs = "root=/dev/sda console=hvc0 earlycon=xen earlyprintk=xen maxcpus=1 clk_ignore_unused";
 
 		dom0 {


### PR DESCRIPTION
Domain-0 doesn't need much memory and setting its size to 512 allows
easier DomU 1:1 mapping used for debugging purposes, so there is no need to
rebuild the device tree if 1:1 is needed.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>