### PR TITLE
ballooning: Fix xen_hotplug_unpopulated visibility, depends from config

### DIFF
--- a/drivers/xen/balloon.c
+++ b/drivers/xen/balloon.c
@@ -73,7 +73,7 @@
 #include <xen/page.h>
 #include <xen/mem-reservation.h>
 
-#if !defined(CONFIG_XT_CMA_HELPER)
+#if !defined(CONFIG_XT_CMA_HELPER) || defined(CONFIG_XEN_BALLOON_MEMORY_HOTPLUG)
 static int xen_hotplug_unpopulated;
 #endif
 


### PR DESCRIPTION
xen_hotplug_unpopulated variable should depend from
CONFIG_XEN_BALLOON_MEMORY_HOTPLUG as long as from CONFIG_XT_CMA_HELPER.

Signed-off-by: Oleksii Moisieiev <oleksii_moisieiev@epam.com>