### PR TITLE
xenvm: remove EXT_MODULES from config

### DIFF
--- a/build.config.xenvm
+++ b/build.config.xenvm
@@ -7,9 +7,6 @@ CROSS_COMPILE_COMPAT=arm-linux-gnueabi-
 LINUX_GCC_CROSS_COMPILE_PREBUILTS_BIN=prebuilts/gas/linux-x86
 LINUX_GCC_CROSS_COMPILE_COMPAT_PREBUILTS_BIN=prebuilts-master/gcc/linux-x86/aarch64/bin
 
-EXT_MODULES="
-imagination
-"
 
 FILES="
 arch/arm64/boot/Image


### PR DESCRIPTION
To be able to build kernel without proprietary
modules - remove EXT_MODULES option by default.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>