### PR TITLE
net: renesas: rswitch: add TSN check for TC redirect actions

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.h
+++ b/drivers/net/ethernet/renesas/rswitch.h
@@ -465,7 +465,7 @@ static inline u32 rswitch_mac_right_half(const u8 *addr)
 	return ((addr[3] << 16) | (addr[4] << 8) | addr[5]);
 }
 
-static inline bool ndev_is_rswitch_dev(const struct net_device *ndev,
+static inline bool ndev_is_tsn_dev(const struct net_device *ndev,
 			struct rswitch_private *priv)
 {
 	int i;
@@ -474,7 +474,8 @@ static inline bool ndev_is_rswitch_dev(const struct net_device *ndev,
 		struct rswitch_device *rdev = priv->rdev[i];
 
 		if (rdev && (rdev->ndev == ndev)) {
-			return true;
+			/* TSN devices contains valid etha pointer, VMQs contains NULL */
+			return (rdev->etha != NULL);
 		}
 	}
 

--- a/drivers/net/ethernet/renesas/rswitch_tc_common.c
+++ b/drivers/net/ethernet/renesas/rswitch_tc_common.c
@@ -26,8 +26,8 @@ int rswitch_tc_validate_flow_action(struct rswitch_device *rdev,
 			}
 			break;
 		case FLOW_ACTION_REDIRECT:
-			if (!ndev_is_rswitch_dev(act->dev, rdev->priv)) {
-				pr_err("Can not redirect to not R-Switch dev!\n");
+			if (!ndev_is_tsn_dev(act->dev, rdev->priv)) {
+				pr_err("Can not redirect to not R-Switch TSN dev!\n");
 				return -EOPNOTSUPP;
 			}
 			redirect = true;

--- a/drivers/net/ethernet/renesas/rswitch_tc_u32.c
+++ b/drivers/net/ethernet/renesas/rswitch_tc_u32.c
@@ -204,8 +204,8 @@ static int rswitch_add_knode(struct net_device *ndev, struct tc_cls_u32_offload 
 		if (is_tcf_mirred_egress_redirect(a)) {
 			struct net_device *target_dev = tcf_mirred_dev(a);
 
-			if (!ndev_is_rswitch_dev(target_dev, rdev->priv)) {
-				pr_err("Can not redirect to not R-Switch dev!\n");
+			if (!ndev_is_tsn_dev(target_dev, rdev->priv)) {
+				pr_err("Can not redirect to not R-Switch TSN dev!\n");
 				return -EOPNOTSUPP;
 			}
 


### PR DESCRIPTION
This commit modifies check for target redirect device in offloaded traffic control rules. It is needed to prevent HW offload of redirect actions to VMQ interfaces (HW offload is supported only between TSN interfaces).

Signed-off-by: Dmytro Firsov <dmytro_firsov@epam.com>