### PR TITLE
net: renesas: rswitch: add VMQ check for R-Switch FIB notifier

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -2599,7 +2599,8 @@ static void rswitch_fib_event_add(struct rswitch_fib_event_work *fib_work)
 		return;
 
 	dev = get_dev_by_ip(fib_work->priv, be32_to_cpu(nh->nh_saddr), false);
-	if (!dev)
+	/* Do not offload routes, related to VMQs (etha equal to NULL) */
+	if (!dev || (dev->etha == NULL))
 		return;
 
 	new_routing_list = kzalloc(sizeof(*new_routing_list), GFP_KERNEL);


### PR DESCRIPTION
This commit adds device check for rswitch_fib_event_add() to ensure, that we are trying to offload TSNx related route. L3 routing offload is not supported for VMQ R-Switch devices.

Signed-off-by: Dmytro Firsov <dmytro_firsov@epam.com>