### PR TITLE
net: renesas: rswitch: WA: explicitly disable unused mapping regs

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -2363,6 +2363,14 @@ int rswitch_setup_pf(struct rswitch_pf_param *pf_param)
 			priv->addr + FWCFMCij(cascade_idx, i));
 	}
 
+	/*
+	 * HW WA: unfilled cascade filter mapping registers may copy values
+	 * from previous cascade filter, so we need explicitly disable them.
+	 */
+	for (i = pf_param->used_entries; i < MAX_PF_ENTRIES; i++) {
+		rs_write32(RSWITCH_PF_DISABLE_FILTER, priv->addr + FWCFMCij(cascade_idx, i));
+	}
+
 	if (pf_param->all_sources) {
 		rs_write32(0x000f007f, priv->addr + FWCFCi(cascade_idx));
 	} else {


### PR DESCRIPTION
This commit workarounds issue related to spurious value copying between cascade filter mapping registers. Issue looks like HW issue, so we just zero and disable unused mapping registers before enabling cascade filter.

Signed-off-by: Dmytro Firsov <dmytro_firsov@epam.com>