### PR TITLE
Several fixes for perfect filters handling

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.h
+++ b/drivers/net/ethernet/renesas/rswitch.h
@@ -80,7 +80,7 @@ enum DIE_DT {
 #define RSWITCH_MAX_NUM_NDEV	8
 #define RSWITCH_MAX_NUM_CHAINS	128
 #define RSWITCH_NUM_IRQ_REGS	(RSWITCH_MAX_NUM_CHAINS / BITS_PER_TYPE(u32))
-#define MAX_PF_ENTRIES (8)
+#define MAX_PF_ENTRIES (7)
 #define RSWITCH_MAX_NUM_L23 256
 
 /* Two-byte filter number */


### PR DESCRIPTION
This series contains patches related to some problems with perfect filters handling:
1. Correct value for max amount of mapped PF per cascade filter;
2. Fix for PF leak during cascade filter freeing;
3. Fix for PF leak in case of cascade filter setup failure.