### PR TITLE
rswtich: vmq: back: fix potential memory leak

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch_xenback.c
+++ b/drivers/net/ethernet/renesas/rswitch_xenback.c
@@ -159,7 +159,7 @@ static int rswitch_vmq_back_probe(struct xenbus_device *dev,
 {
 	int err = 0;
 	struct xenbus_transaction xbt;
-	char *type_str;
+	char *type_str = NULL;
 
 	struct rswitch_vmq_back_info *be = kzalloc(sizeof(*be), GFP_KERNEL);
 
@@ -174,7 +174,8 @@ static int rswitch_vmq_back_probe(struct xenbus_device *dev,
 	if (!be->rswitch_priv)
 	{
 		xenbus_dev_fatal(dev, -ENODEV, "Failed to get rswitch priv data");
-		return -ENODEV;
+		err = -ENODEV;
+		goto fail;
 	}
 	be->tx_chain = rswitch_gwca_get(be->rswitch_priv);
 	be->rx_chain = rswitch_gwca_get(be->rswitch_priv);
@@ -210,8 +211,7 @@ static int rswitch_vmq_back_probe(struct xenbus_device *dev,
 			xenbus_dev_fatal(dev, err,
 					 "Failed to allocate local rdev: %d ",
 					 err);
-			kfree(type_str);
-			return err;
+			goto fail;
 		}
 	}
 	else if (strcmp(type_str, "tsn") == 0) {
@@ -219,18 +219,17 @@ static int rswitch_vmq_back_probe(struct xenbus_device *dev,
 
 		if (be->if_num > RSWITCH_MAX_NUM_ETHA) {
 			xenbus_dev_fatal(dev, err, "Invalid device tsn%d ", be->if_num);
-			kfree(type_str);
-			return -ENODEV;
+			err = -ENODEV;
+			goto fail;
 		}
 
 		be->type = RSWITCH_PV_TSN;
 		netif_dormant_on(rdev->ndev);
 	} else {
 		xenbus_dev_fatal(dev, err, "Unknown device type: %s ", type_str);
-		kfree(type_str);
-		return -ENODEV;
+		err = -ENODEV;
+		goto fail;
 	}
-	kfree(type_str);
 
 	do {
 		err = xenbus_transaction_start(&xbt);
@@ -274,16 +273,28 @@ static int rswitch_vmq_back_probe(struct xenbus_device *dev,
 
 	xenbus_switch_state(dev, XenbusStateInitWait);
 
+	kfree(type_str);
+
 	return 0;
 
 abort_transaction:
 	xenbus_transaction_end(xbt, 1);
 	xenbus_dev_fatal(dev, err, "Failed to write xenstore info\n");
 fail:
+	kfree(type_str);
+
+	if (be->type == RSWITCH_PV_TSN) {
+		struct rswitch_device *rdev =
+			be->rswitch_priv->rdev[be->if_num];
+		netif_dormant_off(rdev->ndev);
+	}
 	if (be->rx_chain)
 		rswitch_gwca_put(be->rswitch_priv, be->rx_chain);
 	if (be->tx_chain)
 		rswitch_gwca_put(be->rswitch_priv, be->tx_chain);
+
+	dev_set_drvdata(&dev->dev, NULL);
+	kfree(be);
 
 	return err;
 }


### PR DESCRIPTION
rswitch_vmq_back_probe() may leak GWCA chains in error path if driver is supplied with invalid device type. Fix this by going to "fail" label.

Also, decrease number of calls to kfree(type_str) by re-arranging them.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>