### PR TITLE
net: renesas: rswitch: Fix memory leak on vlan register

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -3944,6 +3944,7 @@ err_rx:
 	rswitch_txdmac_free(dev, priv);
 err_tx:
 	list_del(&rdev->list);
+	kfree(rdev);
 	return ret;
 }
 
@@ -3961,6 +3962,7 @@ static void vlan_dev_unregister(struct net_device *dev)
 	napi_disable(&rdev->napi);
 
 	list_del(&rdev->list);
+	kfree(rdev);
 }
 
 static int vlan_device_event(struct notifier_block *unused, unsigned long event,


### PR DESCRIPTION
Signed-off-by: Mykyta Poturai <mykyta_poturai@epam.com>
Suggested-by: Leonid Komarianskyi <leonid_komarianskyi@epam.com>