### PR TITLE
FIXUP: net: renesas: rswitch: Moved tc implementations to separate files

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -1147,10 +1147,8 @@ static inline bool skb_is_vlan(struct sk_buff *skb)
 }
 
 static bool rswitch_rx_chain(struct net_device *ndev, int *quota, struct rswitch_gwca_chain *c, bool learn_chain)
-//static bool rswitch_rx(struct net_device *ndev, int *quota)
 {
 	struct rswitch_device *rdev = ndev_to_rdev(ndev);
-//	struct rswitch_gwca_chain *c = rdev->rx_chain;
 	int boguscnt = c->dirty + c->num_ring - c->cur;
 	int entry = c->cur % c->num_ring;
 	struct rswitch_ext_ts_desc *desc = &c->ts_ring[entry];

--- a/drivers/net/ethernet/renesas/rswitch.h
+++ b/drivers/net/ethernet/renesas/rswitch.h
@@ -226,36 +226,6 @@ struct rswitch_mfwd {
 	int num_mac_table_entries;
 };
 
-#if 0
-struct rswitch_ipv4_route {
-	u32 ip;
-	u32 subnet;
-	u32 mask;
-	struct rswitch_device *dev;
-	struct list_head param_list;
-	struct list_head list;
-};
-/* TODO: make common struct for filters */
-struct rswitch_tc_u32_filter {
-	u32 handle;
-	u32 value;
-	u32 mask;
-	u32 offset;
-	u8 dmac[ETH_ALEN];
-	enum rswitch_tc_u32_action action;
-	struct rswitch_device *rdev;
-	struct rswitch_device *target_rdev;
-	struct list_head list;
-	struct l3_ipv4_fwd_param param;
-};
-struct rswitch_tc_flower_filter {
-	struct rswitch_device *rdev;
-	unsigned long cookie;
-	struct l3_ipv4_fwd_param param;
-	struct list_head lh;
-};
-#endif
-
 /* Two-byte filter number */
 #define PFL_TWBF_N (48)
 /* Three-byte filter number */
@@ -394,12 +364,7 @@ struct l3_ipv4_fwd_param {
 	u8 frame_type;
 	bool enable_sub_dst;
 };
-/*
-struct l3_ipv4_fwd_param_list {
-	struct l3_ipv4_fwd_param *param;
-	struct list_head list;
-};
-*/
+
 int rswitch_add_l3fwd(struct l3_ipv4_fwd_param *param);
 int rswitch_remove_l3fwd(struct l3_ipv4_fwd_param *param);
 void rswitch_put_pf(struct l3_ipv4_fwd_param *param);


### PR DESCRIPTION
This commit removes garbage code from commit 92fdac5f96aeb0b89adbdb8bbb82f6006, that appeared during branch rebasing. It will be squashed during migration to next kernel revision

Signed-off-by: Dmytro Firsov <dmytro_firsov@epam.com>