### PR TITLE
rswitch: fix parallel mod

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch_xenback.c
+++ b/drivers/net/ethernet/renesas/rswitch_xenback.c
@@ -4,7 +4,6 @@
  * Copyright (C) 2022 EPAM Systems
  */
 
-#include "linux/err.h"
 #include <linux/etherdevice.h>
 #include <linux/platform_device.h>
 #include <xen/interface/grant_table.h>


### PR DESCRIPTION
There is option, when R-Switch is managed by OS running on Corte R core. In this case, Linux R-Switch driver is allowed to access only TSN0 and GWCA1. 

Fix this mode in our branch by disabling all advanced functionality like HW offload, VLAN support, mirroring and so on, as it depends on MFWD, which should not be accessed in tha parallel mode.