### PR TITLE
net: renesas: rswitch: optimize PF usage

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -843,16 +843,6 @@ enum rswitch_etha_mode {
 #define L3_SLV_DESC_SHIFT (36)
 #define L3_SLV_DESC_MASK (0xFUL << L3_SLV_DESC_SHIFT)
 
-#define filter_index_check(idx, idx_max) \
-	(idx < idx_max) ? idx : -1;
-
-#define get_two_byte_filter(priv) \
-	filter_index_check(find_first_zero_bit(priv->filters.two_bytes, PFL_TWBF_N), PFL_TWBF_N)
-#define get_three_byte_filter(priv) \
-	filter_index_check(find_first_zero_bit(priv->filters.three_bytes, PFL_THBF_N), PFL_THBF_N)
-#define get_four_byte_filter(priv) \
-	filter_index_check(find_first_zero_bit(priv->filters.four_bytes, PFL_FOBF_N), PFL_FOBF_N)
-
 #define FWPC0_DEFAULT	(FWPC0_LTHTA | FWPC0_IP4UE | FWPC0_IP4TE | \
 			 FWPC0_IP4OE | FWPC0_L2SE | FWPC0_IP4EA | \
 			 FWPC0_IPDSA | FWPC0_IPHLA | FWPC0_MACSDA | \

--- a/drivers/net/ethernet/renesas/rswitch.h
+++ b/drivers/net/ethernet/renesas/rswitch.h
@@ -238,6 +238,15 @@ struct rswitch_mfwd {
 /* Cascade filter number */
 #define PFL_CADF_N (64)
 
+#define filter_index_check(idx, idx_max) ((idx) < (idx_max)) ? (idx) : -1
+
+#define get_two_byte_filter(priv) \
+	filter_index_check(find_first_zero_bit(priv->filters.two_bytes, PFL_TWBF_N), PFL_TWBF_N)
+#define get_three_byte_filter(priv) \
+	filter_index_check(find_first_zero_bit(priv->filters.three_bytes, PFL_THBF_N), PFL_THBF_N)
+#define get_four_byte_filter(priv) \
+	filter_index_check(find_first_zero_bit(priv->filters.four_bytes, PFL_FOBF_N), PFL_FOBF_N)
+
 struct rswitch_filters {
 	DECLARE_BITMAP(two_bytes, PFL_TWBF_N);
 	DECLARE_BITMAP(three_bytes, PFL_THBF_N);
@@ -444,17 +453,6 @@ static inline struct rswitch_device *rswitch_find_rdev_by_port(struct rswitch_pr
 	return NULL;
 }
 
-/* Used for three byte filter configuration values in expand mode */
-static inline u32 rswitch_mac_left_half(const u8 *addr)
-{
-	return ((addr[0] << 16) | (addr[1] << 8) | addr[2]);
-}
-
-static inline u32 rswitch_mac_right_half(const u8 *addr)
-{
-	return ((addr[3] << 16) | (addr[4] << 8) | addr[5]);
-}
-
 static inline bool ndev_is_tsn_dev(const struct net_device *ndev,
 			struct rswitch_private *priv)
 {
@@ -514,6 +512,26 @@ static inline int rswitch_init_tag_mask_pf_entry(struct rswitch_pf_param *p,
 	p->entries[idx].val = value;
 	p->entries[idx].mask = mask;
 	p->entries[idx].off = offset;
+	p->used_entries++;
+
+	return 0;
+}
+
+static inline int rswitch_init_tag_expand_pf_entry(struct rswitch_pf_param *p,
+						   u32 value, u32 expand_value)
+{
+	int idx = p->used_entries;
+
+	if (idx >= MAX_PF_ENTRIES)
+		return -E2BIG;
+
+	p->entries[idx].match_mode = RSWITCH_PF_EXPAND_MODE;
+	p->entries[idx].filtering_mode = RSWITCH_PF_TAG_FILTERING;
+	/* Tag filtering supported only for two-byte filters */
+	p->entries[idx].type = PF_TWO_BYTE;
+	p->entries[idx].val = value;
+	p->entries[idx].ext_val = expand_value;
+	p->entries[idx].off = 0;
 	p->used_entries++;
 
 	return 0;

--- a/drivers/net/ethernet/renesas/rswitch_tc_common.c
+++ b/drivers/net/ethernet/renesas/rswitch_tc_common.c
@@ -9,6 +9,28 @@
 #include "rswitch_tc_filters.h"
 #include "rswitch_tc_common.h"
 
+enum possible_combination {
+	/* Can be matched by any filter */
+	ONE_B = 1,
+	/* Can be matched by any filter */
+	TWO_B = 2,
+	/* Can be matched by three or four byte filter in mask mode */
+	THREE_B = 3,
+	/* Can be matched by four byte filter in mask mode or two byte filter in expand mode */
+	FOUR_B = 4,
+	/* Can be matched by three byte filter in expand mode only */
+	SIX_B = 6,
+	/* Can be matched by four byte filter in expand mode only */
+	EIGHT_B = 8,
+};
+
+/* The number of PF used for current iterations for the further setup */
+struct used_pf_entries {
+	int two_byte;
+	int three_byte;
+	int four_byte;
+};
+
 int rswitch_tc_validate_flow_action(struct rswitch_device *rdev,
 				struct flow_rule *rule)
 {
@@ -152,4 +174,315 @@ int rswitch_tc_setup_flow_action(struct rswitch_tc_filter *f,
 	}
 
 	return -EOPNOTSUPP;
+}
+
+/* Find the least used filter to match four bytes */
+static enum pf_type get_four_byte_matcher(struct rswitch_private *priv,
+					  struct used_pf_entries *pf_entries)
+{
+	int used_two_bytes_hw, used_four_bytes_hw;
+	int relative_two_bytes_used, relative_four_bytes_used;
+
+	used_two_bytes_hw = get_two_byte_filter(priv);
+	used_four_bytes_hw = get_four_byte_filter(priv);
+	relative_two_bytes_used =
+		((used_two_bytes_hw + pf_entries->two_byte) * 100) / PFL_TWBF_N;
+	relative_four_bytes_used =
+		((used_four_bytes_hw + pf_entries->four_byte) * 100) / PFL_FOBF_N;
+
+	if (used_two_bytes_hw > 0 &&
+	    relative_two_bytes_used < relative_four_bytes_used) {
+		return PF_TWO_BYTE;
+	}
+
+	return PF_FOUR_BYTE;
+}
+
+/* Find the least used filter to match three bytes */
+static enum pf_type get_three_byte_matcher(struct rswitch_private *priv,
+					   struct used_pf_entries *pf_entries)
+{
+	int used_three_bytes_hw, used_four_bytes_hw;
+	int relative_three_bytes_used, relative_four_bytes_used;
+
+	used_three_bytes_hw = get_three_byte_filter(priv);
+	used_four_bytes_hw = get_four_byte_filter(priv);
+	relative_three_bytes_used =
+		((used_three_bytes_hw + pf_entries->three_byte) * 100) / PFL_THBF_N;
+	relative_four_bytes_used =
+		((used_four_bytes_hw + pf_entries->four_byte) * 100) / PFL_FOBF_N;
+
+	if (used_three_bytes_hw > 0 &&
+	    relative_three_bytes_used < relative_four_bytes_used) {
+		return PF_THREE_BYTE;
+	}
+
+	return PF_FOUR_BYTE;
+}
+
+/* Find the least used filter to match one or two bytes */
+static enum pf_type get_one_or_two_byte_matcher(struct rswitch_private *priv,
+						struct used_pf_entries *pf_entries)
+{
+	int used_two_bytes_hw, used_three_bytes_hw, used_four_bytes_hw;
+	int relative_two_bytes_used, relative_three_bytes_used, relative_four_bytes_used;
+
+	used_two_bytes_hw = get_two_byte_filter(priv);
+	used_three_bytes_hw = get_three_byte_filter(priv);
+	used_four_bytes_hw = get_four_byte_filter(priv);
+	relative_two_bytes_used =
+		((used_two_bytes_hw + pf_entries->two_byte) * 100) / PFL_TWBF_N;
+	relative_three_bytes_used =
+		((used_three_bytes_hw + pf_entries->three_byte) * 100) / PFL_THBF_N;
+	relative_four_bytes_used =
+		((used_four_bytes_hw + pf_entries->four_byte) * 100) / PFL_FOBF_N;
+
+	if (used_four_bytes_hw >= 0 && relative_four_bytes_used < relative_two_bytes_used &&
+	    relative_four_bytes_used < relative_three_bytes_used) {
+		return PF_FOUR_BYTE;
+	}
+
+	if (used_three_bytes_hw >= 0 && relative_three_bytes_used < relative_two_bytes_used &&
+	    relative_three_bytes_used < relative_four_bytes_used) {
+		return PF_THREE_BYTE;
+	}
+
+	return PF_TWO_BYTE;
+}
+
+static int add_param_entry(struct rswitch_pf_param *param, int offset, struct filtering_vector *fv,
+			   u8 mask_lb, int len, struct used_pf_entries *pf_entries)
+{
+	enum pf_type pf_type;
+	u32 val32 = 0, ext_val32 = 0, mask;
+	struct rswitch_private *priv = param->rdev->priv;
+	int rc;
+
+	switch (len) {
+	case EIGHT_B:
+		memcpy(&val32, &fv->values[offset], FOUR_B);
+		memcpy(&ext_val32, &fv->values[offset + FOUR_B], FOUR_B);
+		val32 = ntohl(val32);
+		ext_val32 = ntohl(ext_val32);
+		rc = rswitch_init_expand_pf_entry(param, PF_FOUR_BYTE, val32, ext_val32, offset);
+		if (!rc)
+			pf_entries->four_byte++;
+		break;
+	case SIX_B:
+		memcpy(&val32, &fv->values[offset], THREE_B);
+		memcpy(&ext_val32, &fv->values[offset + THREE_B], THREE_B);
+		val32 = ntohl(val32) >> 8;
+		ext_val32 = ntohl(ext_val32) >> 8;
+		rc = rswitch_init_expand_pf_entry(param, PF_THREE_BYTE, val32, ext_val32, offset);
+		pf_entries->three_byte++;
+		break;
+	case FOUR_B:
+		pf_type = get_four_byte_matcher(priv, pf_entries);
+		if (pf_type == PF_TWO_BYTE && mask_lb == 0xff) {
+			memcpy(&val32, &fv->values[offset], TWO_B);
+			memcpy(&ext_val32, &fv->values[offset + TWO_B], TWO_B);
+			val32 = ntohs(val32);
+			ext_val32 = ntohs(ext_val32);
+			rc = rswitch_init_expand_pf_entry(param, PF_TWO_BYTE, val32, ext_val32,
+							  offset);
+			if (!rc)
+				pf_entries->two_byte++;
+		} else {
+			memcpy(&val32, &fv->values[offset], FOUR_B);
+			mask = ntohl(0xffffff00 | mask_lb);
+			val32 = ntohl(val32);
+			rc = rswitch_init_mask_pf_entry(param, PF_FOUR_BYTE, val32, mask, offset);
+			if (!rc)
+				pf_entries->four_byte++;
+		}
+		break;
+	case THREE_B:
+		pf_type = get_three_byte_matcher(priv, pf_entries);
+		memcpy(&val32, &fv->values[offset], THREE_B);
+		mask = ntohl(0xffff00 | mask_lb);
+		if (pf_type == PF_FOUR_BYTE) {
+			val32 = ntohl(val32);
+			rc = rswitch_init_mask_pf_entry(param, PF_FOUR_BYTE, val32, mask,
+							offset);
+			if (!rc)
+				pf_entries->four_byte++;
+		} else {
+			val32 = ntohl(val32) >> 8;
+			mask = mask >> 8;
+			rc = rswitch_init_mask_pf_entry(param, PF_THREE_BYTE, val32, mask, offset);
+			if (!rc)
+				pf_entries->three_byte++;
+		}
+		break;
+	case TWO_B:
+		pf_type = get_one_or_two_byte_matcher(priv, pf_entries);
+		memcpy(&val32, &fv->values[offset], TWO_B);
+		if (pf_type == PF_TWO_BYTE) {
+			val32 = ntohs(val32);
+			mask = ntohs(0xff00 | mask_lb);
+			rc = rswitch_init_mask_pf_entry(param, pf_type, val32, mask, offset);
+			if (!rc)
+				pf_entries->two_byte++;
+		} else if (pf_type == PF_THREE_BYTE) {
+			val32 = ntohl(val32) >> 8;
+			mask = ntohl(0xff00 | mask_lb) >> 8;
+			rc = rswitch_init_mask_pf_entry(param, pf_type, val32, mask, offset);
+			if (!rc)
+				pf_entries->three_byte++;
+		} else {
+			val32 = ntohl(val32);
+			mask = ntohl(0xff00 | mask_lb);
+			rc = rswitch_init_mask_pf_entry(param, pf_type, val32, mask, offset);
+			if (!rc)
+				pf_entries->four_byte++;
+		}
+		break;
+	case ONE_B:
+		pf_type = get_one_or_two_byte_matcher(priv, pf_entries);
+		memcpy(&val32, &fv->values[offset], ONE_B);
+		if (pf_type == PF_TWO_BYTE) {
+			val32 = ntohs(val32);
+			mask = ntohs(mask_lb);
+			rc = rswitch_init_mask_pf_entry(param, pf_type, val32, mask, offset);
+			if (!rc)
+				pf_entries->two_byte++;
+		} else if (pf_type == PF_THREE_BYTE) {
+			val32 = ntohl(val32) >> 8;
+			mask = ntohl(mask_lb) >> 8;
+			rc = rswitch_init_mask_pf_entry(param, pf_type, val32, mask, offset);
+			if (!rc)
+				pf_entries->three_byte++;
+		} else {
+			val32 = ntohl(val32);
+			mask = ntohl(mask_lb);
+			rc = rswitch_init_mask_pf_entry(param, pf_type, val32, mask, offset);
+			if (!rc)
+				pf_entries->four_byte++;
+		}
+		break;
+	default:
+		/* Can't be matched (e.g. 5 or 7 len) by one filter
+		 * so separate it on two entries
+		 */
+		rc = add_param_entry(param, offset, fv, 0xff, FOUR_B, pf_entries);
+		if (!rc) {
+			rc = add_param_entry(param, offset + FOUR_B, fv, mask_lb,
+					     len - FOUR_B, pf_entries);
+		}
+		break;
+	}
+
+	return rc;
+}
+
+static int rswitch_fill_vlan_pf_param(struct rswitch_pf_param *pf_param,
+				      struct filtering_vector *fv,
+				      struct used_pf_entries *pf_entries)
+{
+	int rc;
+	u32 mask;
+	u16 val16, mask16, ext_val16;
+
+	memcpy(&mask, fv->vlan_masks, sizeof(mask));
+
+	if (mask == 0xffffffff) {
+		memcpy(&val16, &fv->vlan_values[0], TWO_B);
+		memcpy(&ext_val16, &fv->vlan_values[TWO_B], TWO_B);
+		rc = rswitch_init_tag_expand_pf_entry(pf_param, ntohs(val16), ntohs(ext_val16));
+		if (!rc)
+			pf_entries->two_byte++;
+		return rc;
+	}
+
+	if (fv->vlan_masks[0] || fv->vlan_masks[1]) {
+		memcpy(&val16, &fv->vlan_values[0], TWO_B);
+		memcpy(&mask16, &fv->vlan_masks[0], TWO_B);
+		rc = rswitch_init_tag_mask_pf_entry(pf_param, ntohs(val16), ntohs(mask16), 0);
+		if (rc)
+			return rc;
+		pf_entries->two_byte++;
+	}
+
+	if (fv->vlan_masks[2] || fv->vlan_masks[3]) {
+		memcpy(&val16, &fv->vlan_values[2], TWO_B);
+		memcpy(&mask16, &fv->vlan_masks[2], TWO_B);
+		rc = rswitch_init_tag_mask_pf_entry(pf_param, ntohs(val16), ntohs(mask16), 2);
+		if (rc)
+			return rc;
+		pf_entries->two_byte++;
+	}
+
+	return 0;
+}
+
+int rswitch_fill_pf_param(struct rswitch_pf_param *pf_param, fv_gen gen_fn,
+			  void *filter_param)
+{
+	struct used_pf_entries pf_entries = { 0 };
+	struct filtering_vector fv = { 0 };
+	int continues_mask = 0, mask_length = 0, i, rc;
+
+	rc = gen_fn(&fv, filter_param);
+	if (rc)
+		return rc;
+
+	/* Set VLAN first to let know how many two byte filters needed for filtering */
+	if (fv.set_vlan) {
+		rc = rswitch_fill_vlan_pf_param(pf_param, &fv, &pf_entries);
+		if (rc)
+			return rc;
+	}
+
+	for (i = 0; i < MAX_MATCH_LEN; i++) {
+		if (fv.masks[i] == 0xff) {
+			if (!continues_mask)
+				continues_mask = 1;
+
+			/* The maximum length that can be matched by one filter is 8 */
+			if (mask_length >= EIGHT_B) {
+				rc = add_param_entry(pf_param, i - mask_length,
+						     &fv, 0xff, mask_length, &pf_entries);
+				if (rc)
+					return rc;
+				mask_length = 0;
+			}
+			mask_length++;
+		} else {
+			/* If the last byte of continues mask is not equal 0xff we have
+			 * to use only mask mode to filter this.
+			 */
+			if (fv.masks[i]) {
+				if (mask_length >= FOUR_B) {
+					rc = add_param_entry(pf_param, i - mask_length,
+							     &fv, 0xff, FOUR_B, &pf_entries);
+					if (rc)
+						return rc;
+					mask_length -= FOUR_B;
+				} else {
+					mask_length++;
+				}
+				rc = add_param_entry(pf_param, i - mask_length + 1,
+						     &fv, fv.masks[i], mask_length, &pf_entries);
+				if (rc)
+					return rc;
+			} else if (continues_mask) {
+				rc = add_param_entry(pf_param, i - mask_length,
+						     &fv, 0xff, mask_length, &pf_entries);
+				if (rc)
+					return rc;
+			}
+
+			continues_mask = 0;
+			mask_length = 0;
+		}
+	}
+
+	if (continues_mask) {
+		rc = add_param_entry(pf_param, i - mask_length, &fv, fv.masks[i - 1], mask_length,
+				     &pf_entries);
+		if (rc)
+			return rc;
+	}
+
+	return 0;
 }

--- a/drivers/net/ethernet/renesas/rswitch_tc_common.h
+++ b/drivers/net/ethernet/renesas/rswitch_tc_common.h
@@ -10,11 +10,26 @@
 
 #include "rswitch_tc_filters.h"
 
+#define MAX_MATCH_LEN (256)
+#define MAX_VLAN_MATCH_LEN (4)
+
+struct filtering_vector {
+	u8 values[MAX_MATCH_LEN];
+	u8 masks[MAX_MATCH_LEN];
+	u8 vlan_values[MAX_VLAN_MATCH_LEN];
+	u8 vlan_masks[MAX_VLAN_MATCH_LEN];
+	bool set_vlan;
+};
+
+typedef int (*fv_gen)(struct filtering_vector *, void *);
+
 int rswitch_tc_validate_flow_action(struct rswitch_device *rdev,
 				struct flow_rule *rule);
 
 int rswitch_tc_setup_flow_action(struct rswitch_tc_filter *f,
 				struct flow_rule *rule);
 
+int rswitch_fill_pf_param(struct rswitch_pf_param *pf_param, fv_gen gen_fn,
+			  void *filter_param);
 
 #endif


### PR DESCRIPTION
In cases when user tries to setup TC filters that overlaps neighboring bytes, we can reduce perfect filter usage. For example: if user setups filtering by source and destination IpV4 addresses, currently we setup 2 four-byte filters in mask mode but with this patch, it converts this case into 1 four-byte filter in expand mode which performs in the same way but saves one four-byte filter entry. Also, in the case when user needs to filter packets by one byte (e.g. proto type) we can use any kind of filter with an appropriate mask to filter this and with this patch, the algorithm will find the less used filter to perform filtering that will balance different perfect filters types usage.

Signed-off-by: Leonid Komarianskyi <leonid_komarianskyi@epam.com>