### PR TITLE
Fix vlan issues

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -4155,6 +4155,7 @@ static void vlan_dev_unregister(struct net_device *dev)
 
 	list_del(&rdev->list);
 	dev->dev.parent = rdev->vlan_parent;
+	kfree(rdev);
 }
 
 static int vlan_device_event(struct notifier_block *unused, unsigned long event,

--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -4149,6 +4149,7 @@ static void vlan_dev_unregister(struct net_device *dev)
 	rswitch_rxdmac_free(dev, priv);
 	rswitch_txdmac_free(dev, priv);
 	napi_disable(&rdev->napi);
+	netif_napi_del(&rdev->napi);
 
 	cleanup_all_routes(rdev);
 

--- a/drivers/net/ethernet/renesas/rswitch.h
+++ b/drivers/net/ethernet/renesas/rswitch.h
@@ -267,7 +267,7 @@ struct rswitch_private {
 
 	struct list_head rdev_list;
 	struct rswitch_device *rmon_dev[RSWITCH_MAX_RMON_DEV];
-	struct mutex rdev_list_lock;
+	rwlock_t rdev_list_lock;
 
 	struct rswitch_gwca gwca;
 	struct rswitch_etha etha[RSWITCH_MAX_NUM_ETHA];
@@ -447,14 +447,14 @@ static inline struct rswitch_device *rswitch_find_rdev_by_port(struct rswitch_pr
 {
 	struct rswitch_device *rdev;
 
-	mutex_lock(&priv->rdev_list_lock);
+	read_lock(&priv->rdev_list_lock);
 	list_for_each_entry(rdev, &priv->rdev_list, list) {
 		if (rdev->port == port) {
-			mutex_unlock(&priv->rdev_list_lock);
+			read_unlock(&priv->rdev_list_lock);
 			return rdev;
 		}
 	}
-	mutex_unlock(&priv->rdev_list_lock);
+	read_unlock(&priv->rdev_list_lock);
 
 	return NULL;
 }

--- a/drivers/net/ethernet/renesas/rswitch.h
+++ b/drivers/net/ethernet/renesas/rswitch.h
@@ -314,6 +314,11 @@ struct rswitch_device {
 	struct list_head tc_u32_list;
 	struct list_head tc_flower_list;
 	struct list_head tc_matchall_list;
+	/* For VLAN devices, kernel constructs ndev and fills needed structures such as dev.parent,
+	 * but for proper chain mapping R-Switch driver requires real device parent. So we need to
+	 * save pointer to ndev->dev.parent and restore it for proper kernel deinit ndev.
+	 */
+	struct device *vlan_parent;
 	bool mondev;
 };
 

--- a/drivers/net/ethernet/renesas/rswitch_xenback.c
+++ b/drivers/net/ethernet/renesas/rswitch_xenback.c
@@ -63,9 +63,9 @@ rswitch_vmq_back_ndev_register(struct rswitch_private *priv, int index)
 	rdev = netdev_priv(ndev);
 	rdev->ndev = ndev;
 	rdev->priv = priv;
-	mutex_lock(&priv->rdev_list_lock);
+	write_lock(&priv->rdev_list_lock);
 	list_add(&rdev->list, &priv->rdev_list);
-	mutex_unlock(&priv->rdev_list_lock);
+	write_unlock(&priv->rdev_list_lock);
 	rdev->port = priv->gwca.index;
 	rdev->etha = NULL;
 	rdev->remote_chain = -1;


### PR DESCRIPTION
This PR fixes several problems:
1. Removing VLAN devices via "ip link del" command. Previously it led to dumping trace and system hanging;
2. Locking for rdev_list that led to system hanging during VLAN (creation new device add routes etc) operation;
3. System hanging because of writing to inoperable chains when pinging VLAN device after device was deleted;
4. Memory leak in VLAN device unregister.