### PR TITLE
net: renesas: rswitch: cosmetic fix naming for rdev and ndev

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -944,7 +944,7 @@ struct rswitch_ipv4_route {
 	u32 subnet;
 	u32 mask;
 	struct fib_nh *nh;
-	struct rswitch_device *dev;
+	struct rswitch_device *rdev;
 	struct list_head param_list;
 	struct list_head list;
 };
@@ -2504,15 +2504,15 @@ static int rswitch_setup_tc_block_cb(enum tc_setup_type type,
 		void *type_data,
 		void *cb_priv)
 {
-	struct net_device *dev = cb_priv;
+	struct net_device *ndev = cb_priv;
 
 	switch (type) {
 		case TC_SETUP_CLSU32:
-			return rswitch_setup_tc_cls_u32(dev, type_data);
+			return rswitch_setup_tc_cls_u32(ndev, type_data);
 		case TC_SETUP_CLSFLOWER:
-			return rswitch_setup_tc_flower(dev, type_data);
+			return rswitch_setup_tc_flower(ndev, type_data);
 		case TC_SETUP_CLSMATCHALL:
-			return rswitch_setup_tc_matchall(dev, type_data);
+			return rswitch_setup_tc_matchall(ndev, type_data);
 		default:
 			return -EOPNOTSUPP;
 	}
@@ -2636,9 +2636,10 @@ const struct net_device_ops rswitch_netdev_ops = {
 //	.ndo_change_mtu = eth_change_mtu,
 };
 
-static int rswitch_add_ipv4_dst_route(struct rswitch_ipv4_route *routing_list, struct rswitch_device *dev, u32 ip)
+static int rswitch_add_ipv4_dst_route(struct rswitch_ipv4_route *routing_list,
+				      struct rswitch_device *rdev, u32 ip)
 {
-	struct rswitch_private *priv = dev->priv;
+	struct rswitch_private *priv = rdev->priv;
 	struct l3_ipv4_fwd_param_list *param_list;
 	struct rswitch_pf_param pf_param = {0};
 	int ret = 0;
@@ -2653,7 +2654,7 @@ static int rswitch_add_ipv4_dst_route(struct rswitch_ipv4_route *routing_list, s
 		goto free_param_list;
 	}
 
-	pf_param.rdev = dev;
+	pf_param.rdev = rdev;
 	pf_param.all_sources = true;
 
 	/* Match only packets with IPv4 EtherType */
@@ -2674,7 +2675,7 @@ static int rswitch_add_ipv4_dst_route(struct rswitch_ipv4_route *routing_list, s
 	param_list->param->priv = priv;
 	param_list->param->dv = BIT(priv->gwca.index);
 	param_list->param->slv = 0x3F;
-	param_list->param->csd = dev->rx_default_chain->index;
+	param_list->param->csd = rdev->rx_default_chain->index;
 	param_list->param->frame_type = LTHSLP0NONE;
 	param_list->param->enable_sub_dst = true;
 	param_list->param->l23_info.priv = priv;
@@ -2682,7 +2683,7 @@ static int rswitch_add_ipv4_dst_route(struct rswitch_ipv4_route *routing_list, s
 	param_list->param->l23_info.update_dst_mac = true;
 	param_list->param->l23_info.routing_port_valid = 0x3F;
 	param_list->param->l23_info.routing_number = rswitch_rn_get(priv);
-	memcpy(param_list->param->l23_info.dst_mac, dev->ndev->dev_addr, ETH_ALEN);
+	memcpy(param_list->param->l23_info.dst_mac, rdev->ndev->dev_addr, ETH_ALEN);
 
 	ret = rswitch_add_l3fwd(param_list->param);
 	if (ret)
@@ -2707,7 +2708,7 @@ static void rswitch_fib_event_add(struct rswitch_fib_event_work *fib_work)
 {
 	struct fib_entry_notifier_info fen = fib_work->fen_info;
 	struct rswitch_ipv4_route *new_routing_list;
-	struct rswitch_device *dev;
+	struct rswitch_device *rdev;
 	struct fib_nh *nh;
 
 	nh = fib_info_nh(fen.fi, 0);
@@ -2715,9 +2716,9 @@ static void rswitch_fib_event_add(struct rswitch_fib_event_work *fib_work)
 	if (fen.type != RTN_UNICAST)
 		return;
 
-	dev = get_dev_by_ip(fib_work->priv, be32_to_cpu(nh->nh_saddr), false);
+	rdev = get_dev_by_ip(fib_work->priv, be32_to_cpu(nh->nh_saddr), false);
 	/* Do not offload routes, related to VMQs (etha equal to NULL and not vlan device) */
-	if (!dev || (dev->etha == NULL && !is_vlan_dev(dev->ndev)))
+	if (!rdev || (!rdev->etha && !is_vlan_dev(rdev->ndev)))
 		return;
 
 	new_routing_list = kzalloc(sizeof(*new_routing_list), GFP_KERNEL);
@@ -2727,12 +2728,12 @@ static void rswitch_fib_event_add(struct rswitch_fib_event_work *fib_work)
 	new_routing_list->ip = be32_to_cpu(nh->nh_saddr);
 	new_routing_list->mask = be32_to_cpu(inet_make_mask(fen.dst_len));
 	new_routing_list->subnet = fen.dst;
-	new_routing_list->dev = dev;
+	new_routing_list->rdev = rdev;
 	INIT_LIST_HEAD(&new_routing_list->param_list);
 
-	mutex_lock(&dev->priv->ipv4_forward_lock);
-	list_add(&new_routing_list->list, &dev->routing_list);
-	mutex_unlock(&dev->priv->ipv4_forward_lock);
+	mutex_lock(&rdev->priv->ipv4_forward_lock);
+	list_add(&new_routing_list->list, &rdev->routing_list);
+	mutex_unlock(&rdev->priv->ipv4_forward_lock);
 
 	/*
 	 * Route with zeroed subnet is default route. It does not need a PF entry
@@ -2741,7 +2742,7 @@ static void rswitch_fib_event_add(struct rswitch_fib_event_work *fib_work)
 	if (!new_routing_list->subnet)
 		return;
 
-	if (!rswitch_add_ipv4_dst_route(new_routing_list, dev, be32_to_cpu(nh->nh_saddr)))
+	if (!rswitch_add_ipv4_dst_route(new_routing_list, rdev, be32_to_cpu(nh->nh_saddr)))
 		nh->fib_nh_flags |= RTNH_F_OFFLOAD;
 	new_routing_list->nh = nh;
 }
@@ -2749,7 +2750,7 @@ static void rswitch_fib_event_add(struct rswitch_fib_event_work *fib_work)
 static void rswitch_fib_event_remove(struct rswitch_fib_event_work *fib_work)
 {
 	struct fib_entry_notifier_info fen = fib_work->fen_info;
-	struct rswitch_device *dev;
+	struct rswitch_device *rdev;
 	struct fib_nh *nh;
 	struct list_head *cur, *tmp;
 	struct rswitch_ipv4_route *routing_list;
@@ -2761,12 +2762,12 @@ static void rswitch_fib_event_remove(struct rswitch_fib_event_work *fib_work)
 	if (fen.type != RTN_UNICAST)
 		return;
 
-	dev = get_dev_by_ip(fib_work->priv, be32_to_cpu(nh->nh_saddr), false);
-	if (!dev)
+	rdev = get_dev_by_ip(fib_work->priv, be32_to_cpu(nh->nh_saddr), false);
+	if (!rdev)
 		return;
 
-	mutex_lock(&dev->priv->ipv4_forward_lock);
-	list_for_each(cur, &dev->routing_list) {
+	mutex_lock(&rdev->priv->ipv4_forward_lock);
+	list_for_each(cur, &rdev->routing_list) {
 		routing_list = list_entry(cur, struct rswitch_ipv4_route, list);
 		if (routing_list->subnet == fen.dst && routing_list->ip == be32_to_cpu(nh->nh_saddr)) {
 			route_found = true;
@@ -2776,7 +2777,7 @@ static void rswitch_fib_event_remove(struct rswitch_fib_event_work *fib_work)
 
 	/* There is nothing to free */
 	if (!route_found) {
-		mutex_unlock(&dev->priv->ipv4_forward_lock);
+		mutex_unlock(&rdev->priv->ipv4_forward_lock);
 		return;
 	}
 
@@ -2789,7 +2790,7 @@ static void rswitch_fib_event_remove(struct rswitch_fib_event_work *fib_work)
 	}
 
 	list_del(&routing_list->list);
-	mutex_unlock(&dev->priv->ipv4_forward_lock);
+	mutex_unlock(&rdev->priv->ipv4_forward_lock);
 
 	kfree(routing_list);
 }
@@ -3704,7 +3705,7 @@ static void rswitch_add_ipv4_forward_all_types(struct l3_ipv4_fwd_param *param,
 					       struct rswitch_ipv4_route *routing_list)
 {
 	struct l3_ipv4_fwd_param_list *param_list[RSWITCH_FRAME_TYPE_NUM] = {0};
-	struct rswitch_private *priv = routing_list->dev->priv;
+	struct rswitch_private *priv = routing_list->rdev->priv;
 	int i;
 
 	for (i = 0; i < RSWITCH_FRAME_TYPE_NUM; i++) {
@@ -3791,8 +3792,8 @@ static struct rswitch_ipv4_route *rswitch_get_route(struct rswitch_private *priv
 static void rswitch_forward_work(struct work_struct *work)
 {
 	struct rswitch_forward_work *fwd_work;
-	struct rswitch_device *dev;
-	struct rswitch_device *real_dev;
+	struct rswitch_device *rdev;
+	struct rswitch_device *real_rdev;
 	struct net_device *real_ndev;
 	struct rswitch_ipv4_route *routing_list = NULL;
 	struct l3_ipv4_fwd_param param = {0};
@@ -3808,16 +3809,16 @@ static void rswitch_forward_work(struct work_struct *work)
 	if (!routing_list)
 		goto free;
 
-	dev = routing_list->dev;
-	if (rswitch_ipv4_resolve(dev, fwd_work->dst_ip, mac))
+	rdev = routing_list->rdev;
+	if (rswitch_ipv4_resolve(rdev, fwd_work->dst_ip, mac))
 		goto free;
 
-	if (is_vlan_dev(dev->ndev)) {
-		real_ndev = vlan_dev_real_dev(dev->ndev);
-		real_dev = netdev_priv(real_ndev);
-		param.dv = BIT(real_dev->port);
+	if (is_vlan_dev(rdev->ndev)) {
+		real_ndev = vlan_dev_real_dev(rdev->ndev);
+		real_rdev = netdev_priv(real_ndev);
+		param.dv = BIT(real_rdev->port);
 	} else {
-		param.dv = BIT(dev->port);
+		param.dv = BIT(rdev->port);
 	}
 	param.csd = 0;
 	param.enable_sub_dst = false;
@@ -4056,9 +4057,9 @@ static void rswitch_deinit(struct rswitch_private *priv)
 	rswitch_desc_free(priv);
 }
 
-static int vlan_dev_register(struct net_device *dev)
+static int vlan_dev_register(struct net_device *ndev)
 {
-	struct net_device *real_dev;
+	struct net_device *real_rdev;
 	struct rswitch_net *rn;
 	struct rswitch_private *priv;
 	struct rswitch_device *rdev, *parent_rdev;
@@ -4067,12 +4068,12 @@ static int vlan_dev_register(struct net_device *dev)
 	rn = net_generic(&init_net, rswitch_net_id);
 	priv = rn->priv;
 
-	real_dev = vlan_dev_real_dev(dev);
+	real_rdev = vlan_dev_real_dev(ndev);
 
-	if (!ndev_is_tsn_dev(real_dev, priv))
+	if (!ndev_is_tsn_dev(real_rdev, priv))
 		return 0;
 
-	parent_rdev = netdev_priv(real_dev);
+	parent_rdev = netdev_priv(real_rdev);
 
 	rdev = kzalloc(sizeof(*rdev), GFP_KERNEL);
 	if (!rdev)
@@ -4081,9 +4082,9 @@ static int vlan_dev_register(struct net_device *dev)
 	 * but for proper chain mapping R-Switch driver requires real device parent. So we need to
 	 * save pointer to ndev->dev.parent and restore it for proper kernel deinit ndev.
 	 */
-	rdev->vlan_parent = dev->dev.parent;
-	dev->dev.parent = real_dev->dev.parent;
-	rdev->ndev = dev;
+	rdev->vlan_parent = ndev->dev.parent;
+	ndev->dev.parent = real_rdev->dev.parent;
+	rdev->ndev = ndev;
 	rdev->priv = priv;
 	INIT_LIST_HEAD(&rdev->routing_list);
 	INIT_LIST_HEAD(&rdev->tc_u32_list);
@@ -4098,19 +4099,19 @@ static int vlan_dev_register(struct net_device *dev)
 	list_add(&rdev->list, &priv->rdev_list);
 	write_unlock(&priv->rdev_list_lock);
 
-	ret = rswitch_txdmac_init(dev, priv, -1);
+	ret = rswitch_txdmac_init(ndev, priv, -1);
 	if (ret)
 		goto err_tx;
-	ret = rswitch_rxdmac_init(dev, priv, -1);
+	ret = rswitch_rxdmac_init(ndev, priv, -1);
 	if (ret)
 		goto err_rx;
 
-	netif_napi_add(dev, &rdev->napi, rswitch_poll, 64);
-	netdev_info(dev, "MAC address %pMn", dev->dev_addr);
+	netif_napi_add(ndev, &rdev->napi, rswitch_poll, 64);
+	netdev_info(ndev, "MAC address %pMn", ndev->dev_addr);
 	napi_enable(&rdev->napi);
 	return 0;
 err_rx:
-	rswitch_txdmac_free(dev, priv);
+	rswitch_txdmac_free(ndev, priv);
 err_tx:
 	list_del(&rdev->list);
 	return ret;
@@ -4140,7 +4141,7 @@ static void cleanup_all_routes(struct rswitch_device *rdev)
 	mutex_unlock(&rdev->priv->ipv4_forward_lock);
 }
 
-static void vlan_dev_unregister(struct net_device *dev)
+static void vlan_dev_unregister(struct net_device *ndev)
 {
 	struct rswitch_device *rdev;
 	struct rswitch_net *rn;
@@ -4148,33 +4149,33 @@ static void vlan_dev_unregister(struct net_device *dev)
 
 	rn = net_generic(&init_net, rswitch_net_id);
 	priv = rn->priv;
-	rdev = ndev_to_rdev(dev);
-	rswitch_rxdmac_free(dev, priv);
-	rswitch_txdmac_free(dev, priv);
+	rdev = ndev_to_rdev(ndev);
+	rswitch_rxdmac_free(ndev, priv);
+	rswitch_txdmac_free(ndev, priv);
 	napi_disable(&rdev->napi);
 	netif_napi_del(&rdev->napi);
 
 	cleanup_all_routes(rdev);
 
 	list_del(&rdev->list);
-	dev->dev.parent = rdev->vlan_parent;
+	ndev->dev.parent = rdev->vlan_parent;
 	kfree(rdev);
 }
 
 static int vlan_device_event(struct notifier_block *unused, unsigned long event,
 			     void *ptr)
 {
-	struct net_device *dev = netdev_notifier_info_to_dev(ptr);
+	struct net_device *ndev = netdev_notifier_info_to_dev(ptr);
 
-	if (!is_vlan_dev(dev))
+	if (!is_vlan_dev(ndev))
 		return NOTIFY_DONE;
 
 	switch (event) {
 	case NETDEV_REGISTER:
-		vlan_dev_register(dev);
+		vlan_dev_register(ndev);
 		break;
 	case NETDEV_UNREGISTER:
-		vlan_dev_unregister(dev);
+		vlan_dev_unregister(ndev);
 		break;
 	}
 

--- a/drivers/net/ethernet/renesas/rswitch_tc_filters.h
+++ b/drivers/net/ethernet/renesas/rswitch_tc_filters.h
@@ -44,13 +44,13 @@ static inline void rswitch_parse_pedit(struct rswitch_tc_filter *f, struct flow_
 	}
 }
 
-int rswitch_setup_tc_flower(struct net_device *dev,
-				struct flow_cls_offload *cls_flower);
+int rswitch_setup_tc_flower(struct net_device *ndev,
+			    struct flow_cls_offload *cls_flower);
 
-int rswitch_setup_tc_cls_u32(struct net_device *dev,
-				 struct tc_cls_u32_offload *cls_u32);
+int rswitch_setup_tc_cls_u32(struct net_device *ndev,
+			     struct tc_cls_u32_offload *cls_u32);
 
-int rswitch_setup_tc_matchall(struct net_device *dev,
-				  struct tc_cls_matchall_offload *cls_matchall);
+int rswitch_setup_tc_matchall(struct net_device *ndev,
+			      struct tc_cls_matchall_offload *cls_matchall);
 
 #endif /* __RSWITCH_TC_FILTERS_H__ */

--- a/drivers/net/ethernet/renesas/rswitch_tc_flower.c
+++ b/drivers/net/ethernet/renesas/rswitch_tc_flower.c
@@ -280,11 +280,11 @@ static int rswitch_tc_flower_setup_match(struct rswitch_tc_filter *f,
 	return 0;
 }
 
-static int rswitch_tc_flower_replace(struct net_device *dev,
-				struct flow_cls_offload *cls_flower)
+static int rswitch_tc_flower_replace(struct net_device *ndev,
+				     struct flow_cls_offload *cls_flower)
 {
 	struct flow_rule *rule = flow_cls_offload_flow_rule(cls_flower);
-	struct rswitch_device *rdev = netdev_priv(dev);
+	struct rswitch_device *rdev = netdev_priv(ndev);
 	struct rswitch_private *priv = rdev->priv;
 	struct rswitch_tc_filter *f;
 	int rc;
@@ -332,10 +332,10 @@ free:
 
 }
 
-static int rswitch_tc_flower_destroy(struct net_device *dev,
-				struct flow_cls_offload *cls_flower)
+static int rswitch_tc_flower_destroy(struct net_device *ndev,
+				     struct flow_cls_offload *cls_flower)
 {
-	struct rswitch_device *rdev = netdev_priv(dev);
+	struct rswitch_device *rdev = netdev_priv(ndev);
 	struct rswitch_tc_filter *f = NULL;
 
 	list_for_each_entry(f, &rdev->tc_flower_list, lh) {
@@ -351,22 +351,22 @@ static int rswitch_tc_flower_destroy(struct net_device *dev,
 	return -ENOENT;
 }
 
-static int rswitch_tc_flower_stats(struct net_device *dev,
-				struct flow_cls_offload *cls_flower)
+static int rswitch_tc_flower_stats(struct net_device *ndev,
+				   struct flow_cls_offload *cls_flower)
 {
 	return -EOPNOTSUPP;
 }
 
-int rswitch_setup_tc_flower(struct net_device *dev,
-				struct flow_cls_offload *cls_flower)
+int rswitch_setup_tc_flower(struct net_device *ndev,
+			    struct flow_cls_offload *cls_flower)
 {
 	switch (cls_flower->command) {
 	case FLOW_CLS_REPLACE:
-		return rswitch_tc_flower_replace(dev, cls_flower);
+		return rswitch_tc_flower_replace(ndev, cls_flower);
 	case FLOW_CLS_DESTROY:
-		return rswitch_tc_flower_destroy(dev, cls_flower);
+		return rswitch_tc_flower_destroy(ndev, cls_flower);
 	case FLOW_CLS_STATS:
-		return rswitch_tc_flower_stats(dev, cls_flower);
+		return rswitch_tc_flower_stats(ndev, cls_flower);
 	default:
 		return -EOPNOTSUPP;
 	}

--- a/drivers/net/ethernet/renesas/rswitch_tc_matchall.c
+++ b/drivers/net/ethernet/renesas/rswitch_tc_matchall.c
@@ -100,14 +100,14 @@ static int rswitch_tc_matchall_destroy(struct net_device *ndev,
 	return -ENOENT;
 }
 
-int rswitch_setup_tc_matchall(struct net_device *dev,
-				  struct tc_cls_matchall_offload *cls_matchall)
+int rswitch_setup_tc_matchall(struct net_device *ndev,
+			      struct tc_cls_matchall_offload *cls_matchall)
 {
 	switch (cls_matchall->command) {
 	case TC_CLSMATCHALL_REPLACE:
-		return rswitch_tc_matchall_replace(dev, cls_matchall);
+		return rswitch_tc_matchall_replace(ndev, cls_matchall);
 	case TC_CLSMATCHALL_DESTROY:
-		return rswitch_tc_matchall_destroy(dev, cls_matchall);
+		return rswitch_tc_matchall_destroy(ndev, cls_matchall);
 	default:
 		return -EOPNOTSUPP;
 	}

--- a/drivers/net/ethernet/renesas/rswitch_tc_u32.c
+++ b/drivers/net/ethernet/renesas/rswitch_tc_u32.c
@@ -282,15 +282,15 @@ static int rswitch_add_knode(struct net_device *ndev, struct tc_cls_u32_offload 
 	return rswitch_add_action_knode(&filter, cls);
 }
 
-int rswitch_setup_tc_cls_u32(struct net_device *dev,
-				 struct tc_cls_u32_offload *cls_u32)
+int rswitch_setup_tc_cls_u32(struct net_device *ndev,
+			     struct tc_cls_u32_offload *cls_u32)
 {
 	switch (cls_u32->command) {
 	case TC_CLSU32_NEW_KNODE:
 	case TC_CLSU32_REPLACE_KNODE:
-		return rswitch_add_knode(dev, cls_u32);
+		return rswitch_add_knode(ndev, cls_u32);
 	case TC_CLSU32_DELETE_KNODE:
-		return rswitch_del_knode(dev, cls_u32);
+		return rswitch_del_knode(ndev, cls_u32);
 	default:
 		return -EOPNOTSUPP;
 	}


### PR DESCRIPTION
In some places, rswitch_device and net_device have the same naming - just "dev" that complicates code. This patch aligns naming for rswitch code - rdev for rswitch_device and ndev for net_device.