### PR TITLE
[HACK] media: xen-front: Guess the size of camera buffer in case of e…

### DIFF
--- a/drivers/media/xen/xen_camera_front_v4l2.c
+++ b/drivers/media/xen/xen_camera_front_v4l2.c
@@ -721,6 +721,14 @@ static int set_format(struct xen_camera_front_v4l2_info *v4l2_info,
 		if (ret == -EIO || ret == -ETIMEDOUT)
 			return ret;
 
+		/*
+		 * XXX Guess the buffer size, otherwise we will get into the trouble
+		 * later on at:
+		 * drivers/media/common/videobuf2/videobuf2-core.c:vb2_core_reqbufs()
+		 * since plane_sizes[0] will be 0.
+		 */
+		v4l2_info->v4l2_buffer_sz = cfg_req.width * cfg_req.height * 4;
+
 		return get_format_helper(v4l2_info, &cfg_resp, f, true);
 	}
 


### PR DESCRIPTION
…rror

We have faced a weird issue which only occurs when the second frontend comes into play (started streaming) when the first frontend is already in the process of streaming.
The result of this issue is the following WARN and impossibility of streaming by the second frontend:
[  528.461318] WARNING: CPU: 2 PID: 627 at drivers/media/common/videobuf2/videobuf2-core.c:806 vb2_core_reqbufs+0x124/0x4a8

It is unclear why this happens (maybe something went wrong at the backend side), this needs to be properly investigated and fixed. It is worth mentioning that the said issue wasn't observed on prod-devel-rcar based on Yocto BSP v5.9.0.

So use a temporary solution at the moment which lets us to get a stream in both domains over the same video device.