### PR TITLE
media: xen-front: Don't mark buffer as queued in prepare

### DIFF
--- a/drivers/media/xen/xen_camera_front_v4l2.c
+++ b/drivers/media/xen/xen_camera_front_v4l2.c
@@ -476,9 +476,6 @@ static int buffer_prepare(struct vb2_buffer *vb)
 		return ret;
 	}
 
-	mutex_lock(&v4l2_info->bufs_lock);
-	xen_buf->is_queued = true;
-	mutex_unlock(&v4l2_info->bufs_lock);
 	return 0;
 }
 


### PR DESCRIPTION
Marking the buffer as queued in prepare causes it to sometimes get processed before the queue function is called and the v4l is ready to handle it, that causes warnings.

The same flag is already being set in the queue function. So skip the setting in prepare.