### PR TITLE
net: renesas: rswitch: do not offload L2 broadcast packets

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -1196,8 +1196,12 @@ static bool rswitch_rx_chain(struct net_device *ndev, int *quota, struct rswitch
 			else
 				skb_set_network_header(skb, sizeof(*ethhdr));
 
-			iphdr = ip_hdr(skb);
-			rswitch_add_ipv4_forward(priv, be32_to_cpu(iphdr->saddr), be32_to_cpu(iphdr->daddr));
+			/* The L2 broadcast packets shouldn't be routed */
+			if (!is_broadcast_ether_addr(ethhdr->h_dest)) {
+				iphdr = ip_hdr(skb);
+				rswitch_add_ipv4_forward(priv, be32_to_cpu(iphdr->saddr),
+							 be32_to_cpu(iphdr->daddr));
+			}
 		}
 
 		c->skb[entry] = NULL;


### PR DESCRIPTION
Currently, sending L2 broadcast messages, when different TSN ports are in different domains but in the same subnet leads to an inoperative state of TSNs and broadcast storm. L2 broadcast packets shouldn't be routed at all, so this kind of packet should be avoided from adding to L3 table.