### PR TITLE
L3 offload fix multicast

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -944,6 +944,7 @@ struct rswitch_fib_event_work {
 struct rswitch_forward_work {
 	struct work_struct work;
 	struct rswitch_private *priv;
+	struct rswitch_device *ingress_dev;
 	u32 src_ip;
 	u32 dst_ip;
 };
@@ -1152,7 +1153,8 @@ static bool rswitch_is_chain_rxed(struct rswitch_gwca_chain *c, u8 unexpected)
 	return false;
 }
 
-void rswitch_add_ipv4_forward(struct rswitch_private *priv, u32 src_ip, u32 dst_ip);
+void rswitch_add_ipv4_forward(struct rswitch_private *priv, struct rswitch_device *ingress_dev,
+			      u32 src_ip, u32 dst_ip);
 
 static inline bool skb_is_vlan(struct sk_buff *skb)
 {
@@ -1213,7 +1215,7 @@ static bool rswitch_rx_chain(struct net_device *ndev, int *quota, struct rswitch
 			/* The L2 broadcast packets shouldn't be routed */
 			if (!is_broadcast_ether_addr(ethhdr->h_dest)) {
 				iphdr = ip_hdr(skb);
-				rswitch_add_ipv4_forward(priv, be32_to_cpu(iphdr->saddr),
+				rswitch_add_ipv4_forward(priv, rdev, be32_to_cpu(iphdr->saddr),
 							 be32_to_cpu(iphdr->daddr));
 			}
 		}
@@ -3981,8 +3983,6 @@ static void rswitch_forward_work(struct work_struct *work)
 		goto free;
 
 	rdev = routing_list->rdev;
-	if (rswitch_ipv4_resolve(rdev, fwd_work->dst_ip, mac))
-		goto free;
 
 	if (is_vlan_dev(rdev->ndev)) {
 		real_ndev = vlan_dev_real_dev(rdev->ndev);
@@ -3991,6 +3991,14 @@ static void rswitch_forward_work(struct work_struct *work)
 	} else {
 		param.dv = BIT(rdev->port);
 	}
+
+	/* Do not reroute traffic to the ingress port to avoid looping */
+	if (param.dv == BIT(fwd_work->ingress_dev->port))
+		goto free;
+
+	if (rswitch_ipv4_resolve(rdev, fwd_work->dst_ip, mac))
+		goto free;
+
 	param.csd = 0;
 	param.enable_sub_dst = false;
 	memcpy(param.l23_info.dst_mac, mac, ETH_ALEN);
@@ -4013,7 +4021,8 @@ free:
 	kfree(fwd_work);
 }
 
-void rswitch_add_ipv4_forward(struct rswitch_private *priv, u32 src_ip, u32 dst_ip)
+void rswitch_add_ipv4_forward(struct rswitch_private *priv, struct rswitch_device *ingress_dev,
+			      u32 src_ip, u32 dst_ip)
 {
 	struct rswitch_forward_work *fwd_work;
 
@@ -4025,6 +4034,7 @@ void rswitch_add_ipv4_forward(struct rswitch_private *priv, u32 src_ip, u32 dst_
 	fwd_work->priv = priv;
 	fwd_work->src_ip = src_ip;
 	fwd_work->dst_ip = dst_ip;
+	fwd_work->ingress_dev = ingress_dev;
 
 	queue_work(priv->rswitch_forward_wq, &fwd_work->work);
 }

--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -1210,8 +1210,12 @@ static bool rswitch_rx_chain(struct net_device *ndev, int *quota, struct rswitch
 			else
 				skb_set_network_header(skb, sizeof(*ethhdr));
 
-			iphdr = ip_hdr(skb);
-			rswitch_add_ipv4_forward(priv, be32_to_cpu(iphdr->saddr), be32_to_cpu(iphdr->daddr));
+			/* The L2 broadcast packets shouldn't be routed */
+			if (!is_broadcast_ether_addr(ethhdr->h_dest)) {
+				iphdr = ip_hdr(skb);
+				rswitch_add_ipv4_forward(priv, be32_to_cpu(iphdr->saddr),
+							 be32_to_cpu(iphdr->daddr));
+			}
 		}
 
 		c->skb[entry] = NULL;


### PR DESCRIPTION
This PR is based on not already merged PR (https://github.com/xen-troops/linux/pull/153), so it contains already reviewed commit. Additionally, this PR contains a fix, that doesn't allow to add of invalid looping rules to L3 table when the destination vector is equal to port from where is traffic is ingressed.