### PR TITLE
xenvm:[WA] introduce no graphic config

### DIFF
--- a/build.config.xenvm.no_graphics
+++ b/build.config.xenvm.no_graphics
@@ -1,0 +1,22 @@
+. ${ROOT_DIR}/${KERNEL_DIR}/build.config.common
+. ${ROOT_DIR}/${KERNEL_DIR}/build.config.aarch64
+. ${ROOT_DIR}/${KERNEL_DIR}/build.config.allmodconfig
+
+DEFCONFIG=android_xenvm_defconfig
+CROSS_COMPILE=aarch64-linux-gnu-
+CROSS_COMPILE_COMPAT=arm-linux-gnueabi-
+LINUX_GCC_CROSS_COMPILE_PREBUILTS_BIN=prebuilts/gas/linux-x86
+LINUX_GCC_CROSS_COMPILE_COMPAT_PREBUILTS_BIN=prebuilts-master/gcc/linux-x86/aarch64/bin
+
+EXT_MODULES="
+modules/vspm
+modules/vspmif
+modules/mmngr
+modules/uvcs
+"
+
+FILES="
+arch/arm64/boot/Image
+vmlinux
+System.map
+"


### PR DESCRIPTION
Since moulin can't provide bash variable with "",
we can't provide EXT_MODULES using variables.
Adding a new config which will be used for the build with prebuild graphics module.