### PR TITLE
Fix hash collisions issue

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -855,6 +855,10 @@ enum rswitch_etha_mode {
 #define FBFILTER_IDX(i) ((i / 2) - PFL_TWBF_N - PFL_THBF_N)
 #define L3_SLV_DESC_SHIFT (36)
 #define L3_SLV_DESC_MASK (0xFUL << L3_SLV_DESC_SHIFT)
+/* Avarage frame size 512 bits (64 bytes) */
+#define AVG_FRAME_SIZE 512
+/* Maximum value of hash collisions */
+#define LTHHMC_MAX_VAL 0x1FF
 
 #define FWPC0(i)                (FWPC00 + (i) * 0x10)
 #define FWPC0_DEFAULT	(FWPC0_LTHTA | FWPC0_IP4UE | FWPC0_IP4TE | \
@@ -4266,7 +4270,7 @@ static void rswitch_fwd_init(struct rswitch_private *priv)
 	/* Enable Direct Descriptors for GWCA1 */
 	rs_write32(FWPC1_DDE, priv->addr + FWPC10 + (priv->gwca.index * 0x10));
 	/* Set L3 hash maximum unsecure entry to 512 */
-	rs_write32(0x200 << 16, priv->addr + FWLTHHEC);
+	rs_write32(0x200 << 16 | priv->max_collisions, priv->addr + FWLTHHEC);
 	/* Disable hash equation */
 	rs_write32(0, priv->addr + FWSFHEC);
 	/* Enable access from unsecure APB for the first 32 update rules */
@@ -4297,6 +4301,51 @@ static void rswitch_fwd_init(struct rswitch_private *priv)
 	/* CPU mirroring */
 	rs_write32(priv->mon_rx_chain->index | (RSWITCH_HW_NUM_TO_GWCA_IDX(priv->gwca.index) << 16),
 		   priv->addr + FWCMPTC);
+}
+
+static void rswitch_set_max_hash_collisions(struct rswitch_private *priv)
+{
+	u64 tsn_throughput = 0, max_throughput;
+	struct device_node *ports, *port, *phy = NULL;
+	int err = 0;
+
+	ports = of_get_child_by_name(priv->pdev->dev.of_node, "ports");
+	if (!ports) {
+		/* Set minimum value for collision number */
+		priv->max_collisions = 1;
+		return;
+	}
+
+	for_each_child_of_node(ports, port) {
+		phy = of_parse_phandle(port, "phy-handle", 0);
+		if (phy) {
+			/* 1 GBit*/
+			tsn_throughput += 1000 * 1000 * 1000;
+		} else {
+			if (of_phy_is_fixed_link(port)) {
+				struct device_node *fixed_link;
+				u32 link_speed;
+
+				fixed_link = of_get_child_by_name(port, "fixed-link");
+				err = of_property_read_u32(fixed_link, "speed", &link_speed);
+				if (err)
+					continue;
+
+				tsn_throughput += link_speed * 1000 * 1000;
+			}
+		}
+	}
+
+	of_node_put(ports);
+	max_throughput = tsn_throughput + priv->gwca.speed * 1000 * 1000;
+
+	/* Calculate maximum collisions number using the formula:
+	 * FWLTHHEC.LTHHMC =
+	 * (clk_freq[Hz] * Average_frame_size[bit] / Incoming_throughput[bps] - 4) / 3
+	 */
+	priv->max_collisions = (((PTP_S4_FREQ * AVG_FRAME_SIZE) / (max_throughput)) - 4) / 3;
+	if (priv->max_collisions > LTHHMC_MAX_VAL)
+		priv->max_collisions = LTHHMC_MAX_VAL;
 }
 
 static int rswitch_init(struct rswitch_private *priv)
@@ -4367,6 +4416,7 @@ static int rswitch_init(struct rswitch_private *priv)
 		if (err < 0)
 			goto forward_wq_destroy;
 
+		rswitch_set_max_hash_collisions(priv);
 		rswitch_fwd_init(priv);
 		err = rtsn_ptp_init(priv->ptp_priv, RTSN_PTP_REG_LAYOUT_S4, RTSN_PTP_CLOCK_S4);
 		if (err < 0)

--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -859,6 +859,14 @@ enum rswitch_etha_mode {
 #define AVG_FRAME_SIZE 512
 /* Maximum value of hash collisions */
 #define LTHHMC_MAX_VAL 0x1FF
+#define FWLTHHC_LTHHE_MAX 0x1FF
+#define FWLTHTLR_LTHLCN_MASK 0x3FF0000
+#define FWLTHTLR_LTHLCN_SHIFT 16
+#define L3_LEARN_COLLISSION_NUM(val) (((val) & FWLTHTLR_LTHLCN_MASK) >> FWLTHTLR_LTHLCN_SHIFT)
+/* Initial value for hash equation that was found experimentally.
+ * Default value "1" leads to more freqent hash collisions.
+ */
+#define HE_INITIAL_VALUE 2
 
 #define FWPC0(i)                (FWPC00 + (i) * 0x10)
 #define FWPC0_DEFAULT	(FWPC0_LTHTA | FWPC0_IP4UE | FWPC0_IP4TE | \
@@ -2333,9 +2341,16 @@ static int rswitch_setup_l23_update(struct l23_update_info *l23_info)
 	return rs_read32(l23_info->priv->addr + FWL23URLR);
 }
 
+static void rswitch_reset_l3_table(struct rswitch_private *priv)
+{
+	rs_write32(LTHTIOG, priv->addr + FWLTHTIM);
+	rswitch_reg_wait(priv->addr, FWLTHTIM, LTHTR, LTHTR);
+}
+
 static int rswitch_modify_l3fwd(struct l3_ipv4_fwd_param *param, bool delete)
 {
 	struct rswitch_private *priv = param->priv;
+	u32 collision_num, res;
 
 	if (!delete) {
 		if (param->l23_info.update_dst_mac || param->l23_info.update_src_mac ||
@@ -2372,12 +2387,121 @@ static int rswitch_modify_l3fwd(struct l3_ipv4_fwd_param *param, bool delete)
 	else
 		rs_write32(param->dv, priv->addr + FWLTHTL9);
 
-	return rswitch_reg_wait(priv->addr, FWLTHTLR, LTHTL, 0);
+	res = rswitch_reg_wait(priv->addr, FWLTHTLR, LTHTL, 0);
+	if (res)
+		return res;
+
+	res = rs_read32(priv->addr + FWLTHTLR);
+	collision_num = L3_LEARN_COLLISSION_NUM(res);
+	if ((collision_num > priv->max_collisions) && !delete)
+		return -EAGAIN;
+
+	return 0;
 }
 
 int rswitch_add_l3fwd(struct l3_ipv4_fwd_param *param)
 {
 	return rswitch_modify_l3fwd(param, false);
+}
+
+/* Should be called with rswitch_priv->ipv4_forward_lock taken */
+static int rswitch_restore_l3_table(struct rswitch_private *priv)
+{
+	struct list_head *cur, *cur_param_list;
+	struct rswitch_ipv4_route *routing_list;
+	struct l3_ipv4_fwd_param_list *param_list;
+#if IS_ENABLED(CONFIG_IP_MROUTE)
+	struct rswitch_ipv4_multi_route *multi_route;
+#endif
+	struct rswitch_device *rdev;
+	int rc = 0;
+
+	read_lock(&priv->rdev_list_lock);
+	list_for_each_entry(rdev, &priv->rdev_list, list) {
+		rc = rswitch_restore_tc_l3_table(rdev);
+		if (rc)
+			goto unlock;
+		list_for_each(cur, &rdev->routing_list) {
+			routing_list = list_entry(cur, struct rswitch_ipv4_route, list);
+			list_for_each(cur_param_list, &routing_list->param_list) {
+				param_list =
+					list_entry(cur_param_list,
+						   struct l3_ipv4_fwd_param_list,
+						   list);
+				rc = rswitch_add_l3fwd(param_list->param);
+				if (rc)
+					goto unlock;
+			}
+		}
+
+#if IS_ENABLED(CONFIG_IP_MROUTE)
+		list_for_each(cur, &rdev->mult_routing_list) {
+			multi_route = list_entry(cur, struct rswitch_ipv4_multi_route, list);
+			rc = rswitch_add_l3fwd(&multi_route->params[0]);
+			if (rc)
+				goto unlock;
+			rc = rswitch_add_l3fwd(&multi_route->params[1]);
+			if (rc)
+				goto unlock;
+		}
+#endif
+	}
+
+unlock:
+	read_unlock(&priv->rdev_list_lock);
+
+	return rc;
+}
+
+/* This function is preferred to use instead of rswitch_add_l3fwd in
+ * case of adding L3 streaming entry. It checks rswitch_add_l3fwd
+ * result and if EAGAIN is returned the function adjusts equation
+ * to reduce the collision number. There is no reason to use it
+ * for perfect filter because in this case, collisions won't happenned.
+ * Should be called with rswitch_priv->ipv4_forward_lock taken.
+ */
+int rswitch_add_l3fwd_adjust_hash(struct l3_ipv4_fwd_param *param)
+{
+	struct rswitch_private *priv = param->priv;
+	int rc;
+	u16 original_equation = priv->hash_equation;
+
+	do {
+		rc = rswitch_add_l3fwd(param);
+		if (rc == -EAGAIN) {
+			do {
+				priv->hash_equation++;
+				/* Try to find appropriate parameters from the beginning again */
+				if (priv->hash_equation > FWLTHHC_LTHHE_MAX)
+					priv->hash_equation = HE_INITIAL_VALUE;
+				/* If we return back to the original state, there are no
+				 * appropriate parameters for current entries and we cannot
+				 * add given entry.
+				 */
+				if (priv->hash_equation == original_equation)
+					rc = -E2BIG;
+
+				rswitch_reset_l3_table(priv);
+				rs_write32(priv->hash_equation, priv->addr + FWLTHHC);
+				rc = rswitch_restore_l3_table(priv);
+			} while (rc == -EAGAIN);
+			if (!rc) {
+				/* Restoring is succeeded, try to add the original entry again */
+				rc = -EAGAIN;
+			} else {
+				/* Some other issue occurred, restoring back
+				 * initial state and return error code.
+				 */
+				priv->hash_equation = original_equation;
+				rswitch_reset_l3_table(priv);
+				rs_write32(priv->hash_equation, priv->addr + FWLTHHC);
+				rswitch_restore_l3_table(priv);
+				return rc;
+			}
+		}
+	} while (rc == -EAGAIN);
+
+	return rc;
 }
 
 static enum pf_type rswitch_get_pf_type_by_num(int num)
@@ -2948,20 +3072,26 @@ static void rswitch_fibmr_event_add(struct rswitch_fib_event_work *fib_work)
 	memcpy(&multi_route->params[1], &multi_route->params[0], sizeof(multi_route->params[1]));
 	multi_route->params[1].frame_type = LTHSLP0v4UDP;
 
-	if (rswitch_add_l3fwd(&multi_route->params[0])) {
+	mutex_lock(&rdev->priv->ipv4_forward_lock);
+	if (rswitch_add_l3fwd_adjust_hash(&multi_route->params[0])) {
+		mutex_unlock(&rdev->priv->ipv4_forward_lock);
 		kfree(multi_route);
 		return;
 	}
 
-	if (rswitch_add_l3fwd(&multi_route->params[1])) {
+	/* Add route to the list after adding the first entry.
+	 * It helps to restore the first one in case of changing hash while
+	 * adding entry to L3 table for UDP.
+	 */
+	list_add(&multi_route->list, &rdev->mult_routing_list);
+	if (rswitch_add_l3fwd_adjust_hash(&multi_route->params[1])) {
+		mutex_unlock(&rdev->priv->ipv4_forward_lock);
 		rswitch_remove_l3fwd(&multi_route->params[0]);
 		kfree(multi_route);
 		return;
 	}
-
-	mutex_lock(&rdev->priv->ipv4_forward_lock);
-	list_add(&multi_route->list, &rdev->mult_routing_list);
 	mutex_unlock(&rdev->priv->ipv4_forward_lock);
+
 	fib_work->men_info.mfc->mfc_flags |= MFC_OFFLOAD;
 }
 
@@ -4093,27 +4223,30 @@ static void rswitch_add_ipv4_forward_all_types(struct l3_ipv4_fwd_param *param,
 	param_list[1]->param->frame_type = LTHSLP0v4UDP;
 	param_list[2]->param->frame_type = LTHSLP0v4TCP;
 
-	if (!priv->ipv4_forward_enabled)
+	if (!priv->ipv4_forward_enabled) {
 		/* Add these params only to list, not to HW */
-		goto list_add;
+		list_add(&param_list[0]->list, &routing_list->param_list);
+		list_add(&param_list[1]->list, &routing_list->param_list);
+		list_add(&param_list[2]->list, &routing_list->param_list);
+		return;
+	}
 
-	if (rswitch_add_l3fwd(param_list[0]->param))
+	if (rswitch_add_l3fwd_adjust_hash(param_list[0]->param))
 		goto free;
 
-	if (rswitch_add_l3fwd(param_list[1]->param)) {
+	list_add(&param_list[0]->list, &routing_list->param_list);
+	if (rswitch_add_l3fwd_adjust_hash(param_list[1]->param)) {
 		rswitch_remove_l3fwd(param_list[0]->param);
 		goto free;
 	}
 
-	if (rswitch_add_l3fwd(param_list[2]->param)) {
+	list_add(&param_list[1]->list, &routing_list->param_list);
+	if (rswitch_add_l3fwd_adjust_hash(param_list[2]->param)) {
 		rswitch_remove_l3fwd(param_list[0]->param);
 		rswitch_remove_l3fwd(param_list[1]->param);
 		goto free;
 	}
 
-list_add:
-	list_add(&param_list[0]->list, &routing_list->param_list);
-	list_add(&param_list[1]->list, &routing_list->param_list);
 	list_add(&param_list[2]->list, &routing_list->param_list);
 
 	return;
@@ -4282,9 +4415,7 @@ static void rswitch_fwd_init(struct rswitch_private *priv)
 	/* Init parameters for IPv4/v6 hash extract */
 	rs_write32(BIT(22) | BIT(23), priv->addr + FWIP4SC);
 	/* Reset L3 table */
-	rs_write32(LTHTIOG, priv->addr + FWLTHTIM);
-	/* TODO: Check result */
-	rswitch_reg_wait(priv->addr, FWLTHTIM, LTHTR, 1);
+	rswitch_reset_l3_table(priv);
 	/* Reset L2/3 update table */
 	rs_write32(LTHTIOG, priv->addr + FWL23UTIM);
 	/* TODO: Check result */
@@ -4301,6 +4432,9 @@ static void rswitch_fwd_init(struct rswitch_private *priv)
 	/* CPU mirroring */
 	rs_write32(priv->mon_rx_chain->index | (RSWITCH_HW_NUM_TO_GWCA_IDX(priv->gwca.index) << 16),
 		   priv->addr + FWCMPTC);
+
+	priv->hash_equation = HE_INITIAL_VALUE;
+	rs_write32(priv->hash_equation, priv->addr + FWLTHHC);
 }
 
 static void rswitch_set_max_hash_collisions(struct rswitch_private *priv)

--- a/drivers/net/ethernet/renesas/rswitch.h
+++ b/drivers/net/ethernet/renesas/rswitch.h
@@ -339,6 +339,10 @@ struct rswitch_private {
 	bool offload_enabled;
 	struct mutex ipv4_forward_lock;
 	struct workqueue_struct *rswitch_forward_wq;
+	/* Maximum number of hash collisions for L3 hash forwarding
+	 * table that can guarantee appropriate speed.
+	 */
+	u16 max_collisions;
 
 	u8 chan_running;
 };

--- a/drivers/net/ethernet/renesas/rswitch.h
+++ b/drivers/net/ethernet/renesas/rswitch.h
@@ -343,6 +343,7 @@ struct rswitch_private {
 	 * table that can guarantee appropriate speed.
 	 */
 	u16 max_collisions;
+	u16 hash_equation;
 
 	u8 chan_running;
 };

--- a/drivers/net/ethernet/renesas/rswitch_tc_common.c
+++ b/drivers/net/ethernet/renesas/rswitch_tc_common.c
@@ -494,3 +494,18 @@ int rswitch_fill_pf_param(struct rswitch_pf_param *pf_param, fv_gen gen_fn,
 
 	return 0;
 }
+
+int rswitch_restore_tc_l3_table(struct rswitch_device *rdev)
+{
+	int rc;
+
+	rc = rswitch_u32_restore_l3(rdev);
+	if (rc)
+		return rc;
+
+	rc = rswitch_matchall_restore_l3(rdev);
+	if (rc)
+		return rc;
+
+	return rswitch_flower_restore_l3(rdev);
+}

--- a/drivers/net/ethernet/renesas/rswitch_tc_common.h
+++ b/drivers/net/ethernet/renesas/rswitch_tc_common.h
@@ -32,4 +32,8 @@ int rswitch_tc_setup_flow_action(struct rswitch_tc_filter *f,
 int rswitch_fill_pf_param(struct rswitch_pf_param *pf_param, fv_gen gen_fn,
 			  void *filter_param);
 
+int rswitch_u32_restore_l3(struct rswitch_device *rdev);
+int rswitch_matchall_restore_l3(struct rswitch_device *rdev);
+int rswitch_flower_restore_l3(struct rswitch_device *rdev);
+
 #endif

--- a/drivers/net/ethernet/renesas/rswitch_tc_filters.h
+++ b/drivers/net/ethernet/renesas/rswitch_tc_filters.h
@@ -53,4 +53,6 @@ int rswitch_setup_tc_cls_u32(struct net_device *ndev,
 int rswitch_setup_tc_matchall(struct net_device *ndev,
 			      struct tc_cls_matchall_offload *cls_matchall);
 
+int rswitch_restore_tc_l3_table(struct rswitch_device *rdev);
+
 #endif /* __RSWITCH_TC_FILTERS_H__ */

--- a/drivers/net/ethernet/renesas/rswitch_tc_flower.c
+++ b/drivers/net/ethernet/renesas/rswitch_tc_flower.c
@@ -371,3 +371,19 @@ int rswitch_setup_tc_flower(struct net_device *ndev,
 		return -EOPNOTSUPP;
 	}
 }
+
+int rswitch_flower_restore_l3(struct rswitch_device *rdev)
+{
+	struct rswitch_tc_filter *filter;
+	struct list_head *cur;
+	int rc;
+
+	list_for_each(cur, &rdev->tc_flower_list) {
+		filter = list_entry(cur, struct rswitch_tc_filter, lh);
+		rc = rswitch_add_l3fwd(&filter->param);
+		if (rc)
+			return rc;
+	}
+
+	return 0;
+}

--- a/drivers/net/ethernet/renesas/rswitch_tc_matchall.c
+++ b/drivers/net/ethernet/renesas/rswitch_tc_matchall.c
@@ -114,3 +114,19 @@ int rswitch_setup_tc_matchall(struct net_device *ndev,
 
 	return -EOPNOTSUPP;
 }
+
+int rswitch_matchall_restore_l3(struct rswitch_device *rdev)
+{
+	struct rswitch_tc_filter *cfg;
+	struct list_head *cur;
+	int rc;
+
+	list_for_each(cur, &rdev->tc_matchall_list) {
+		cfg = list_entry(cur, struct rswitch_tc_filter, lh);
+		rc = rswitch_add_l3fwd(&cfg->param);
+		if (rc)
+			return rc;
+	}
+
+	return 0;
+}

--- a/drivers/net/ethernet/renesas/rswitch_tc_u32.c
+++ b/drivers/net/ethernet/renesas/rswitch_tc_u32.c
@@ -297,3 +297,19 @@ int rswitch_setup_tc_cls_u32(struct net_device *ndev,
 
 	return -EOPNOTSUPP;
 }
+
+int rswitch_u32_restore_l3(struct rswitch_device *rdev)
+{
+	struct rswitch_tc_filter *tc_u32_cfg;
+	struct list_head *cur;
+	int rc;
+
+	list_for_each(cur, &rdev->tc_u32_list) {
+		tc_u32_cfg = list_entry(cur, struct rswitch_tc_filter, lh);
+		rc = rswitch_add_l3fwd(&tc_u32_cfg->param);
+		if (rc)
+			return rc;
+	}
+
+	return 0;
+}

--- a/drivers/net/ethernet/renesas/rtsn_ptp.h
+++ b/drivers/net/ethernet/renesas/rtsn_ptp.h
@@ -10,6 +10,7 @@
 #include <linux/ptp_clock_kernel.h>
 
 #define PTPTIVC_INIT	0x19000000	/* 320MHz */
+#define PTP_S4_FREQ	320000000ULL
 
 #define GTIVC_INIT	0x50000000	/* 100MHz */
 


### PR DESCRIPTION
In some cases, L3 offload does not work because the number of hash collisions becomes larger than zero while adding the rules to L3 table. To fix this issue, implemented 2 patches:
1) Set appropriate maximum number of collisions according to the formula from documentation:
FWLTHHEC.LTHHMC = (clk_freq[Hz] * Average_frame_size[bit] / Incoming_throughput[bps] - 4) / 3

2) As the maximum number of hash collisions can be exceeded (due to large number of L3 rules), implemented mechanism that is able to find more suitable hash equation and set appropriate value to FWLTHHC register to reduce collisions without dropping throughput.