### PR TITLE
net: ethernet: renesas: rswitch: Fix a lot of redundant irq issue

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.h
+++ b/drivers/net/ethernet/renesas/rswitch.h
@@ -346,6 +346,7 @@ struct rswitch_private {
 	u16 hash_equation;
 
 	u8 chan_running;
+	spinlock_t lock;	/* lock interrupt registers' control */
 };
 
 enum pf_type {


### PR DESCRIPTION
Backported from upstream to fix a lot of redudant irq issue. https://lore.kernel.org/netdev/20230913112429.GQ401982@kernel.org/T/

This patch improves VMQ performance during communication:
DomU(VMQ) <---> DomD(VMQ) <---> Host PC
From ~31MB/s to ~50MB/s.