### PR TITLE
net: renesas: rswitch: refactor data IRQ handling

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.h
+++ b/drivers/net/ethernet/renesas/rswitch.h
@@ -232,8 +232,7 @@ struct rswitch_gwca {
 	struct rswitch_gwca_chain ts_queue;
 	struct list_head ts_info_list;
 	DECLARE_BITMAP(used, RSWITCH_MAX_NUM_CHAINS);
-	u32 tx_irq_bits[RSWITCH_NUM_IRQ_REGS];
-	u32 rx_irq_bits[RSWITCH_NUM_IRQ_REGS];
+	u32 registered_irqs[RSWITCH_NUM_IRQ_REGS];
 	int speed;
 };
 


### PR DESCRIPTION
R-Switch driver had a lot of old staff related to interrupt handling. Some parts was changed some time ago, but variables and approaches, that are not longer needed was not removed.

All extra routines (rswitch_data_irq, rswitch_get_data_irq_status etc.) were removed and now actions related to IRQ handling are made in rswitch_irq() routine. This should decrease number of function calls and loop iterations.

Also, replace redundant rx/tx_irq bitfields, that were not used in proper way - now only registered_irqs are stored. It is needed to distinguish chains, that are used but not registered yet.