### PR TITLE
VMQ refactoring & optimization

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -2468,8 +2468,6 @@ static int rswitch_start_xmit(struct sk_buff *skb, struct net_device *ndev)
 		desc->info1 |= ((u64)rdev->remote_chain << INFO1_CSD1_SHIFT) |
 			((BIT(rdev->port)) << INFO1_DV_SHIFT) | INFO1_FMT;
 
-	dma_wmb();
-
 	if (num_desc > 1) {
 		for (i = num_desc - 1; i >= 0; i--) {
 			desc = &c->tx_ring[(entry + i) % c->num_ring];
@@ -2484,6 +2482,8 @@ static int rswitch_start_xmit(struct sk_buff *skb, struct net_device *ndev)
 		desc = &c->tx_ring[entry];
 		desc->die_dt = DT_FSINGLE | DIE;
 	}
+
+	dma_wmb();
 
 	c->cur += num_desc;
 	rswitch_trigger_chain(rdev->priv, c);

--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -2488,6 +2488,11 @@ static int rswitch_start_xmit(struct sk_buff *skb, struct net_device *ndev)
 	c->cur += num_desc;
 	rswitch_trigger_chain(rdev->priv, c);
 
+	/* We won't have enough free descriptors on the next call, so
+	 * it's better to stop tx subqueue now without returning error.
+	 */
+	if (unlikely(c->cur - c->dirty >= c->num_ring))
+		netif_stop_subqueue(ndev, 0);
 out:
 	spin_unlock_irqrestore(&rdev->lock, flags);
 

--- a/drivers/net/ethernet/renesas/rswitch.h
+++ b/drivers/net/ethernet/renesas/rswitch.h
@@ -274,6 +274,14 @@ struct rswitch_filters {
 	DECLARE_BITMAP(cascade, PFL_CADF_N);
 };
 
+enum rdev_type {
+	RSWITCH_TSN_DEV,
+	RSWITCH_VMQ_BACK_DEV,
+	RSWITCH_VMQ_FRONT_DEV,
+	RSWITCH_VLAN_DEV,
+	RSWITCH_MON_DEV,
+};
+
 struct rswitch_device {
 	struct list_head list;
 	struct rswitch_private *priv;
@@ -306,6 +314,7 @@ struct rswitch_device {
 	 */
 	struct device *vlan_parent;
 	bool mondev;
+	enum rdev_type rdev_type;
 };
 
 struct rswitch_private {

--- a/drivers/net/ethernet/renesas/rswitch.h
+++ b/drivers/net/ethernet/renesas/rswitch.h
@@ -216,6 +216,7 @@ struct rswitch_gwca_chain {
 #define RSWITCH_MAX_CTAG_PCP	7
 #define MAX_MTU_SZ		9000
 #define MAX_DESC_SZ		2048
+#define VMQ_INFO_VERSION	1
 
 struct rswitch_gwca_ts_info {
 	struct sk_buff *skb;
@@ -282,6 +283,14 @@ enum rdev_type {
 	RSWITCH_MON_DEV,
 };
 
+struct rswitch_vmq_status {
+	u32 version;
+	u64 front_tx, front_rx;
+	u64 back_tx, back_rx;
+	u64 tx_front_ring_size, rx_front_ring_size;
+	u64 tx_back_ring_size, rx_back_ring_size;
+};
+
 struct rswitch_device {
 	struct list_head list;
 	struct rswitch_private *priv;
@@ -315,6 +324,7 @@ struct rswitch_device {
 	struct device *vlan_parent;
 	bool mondev;
 	enum rdev_type rdev_type;
+	struct rswitch_vmq_status *vmq_info;
 };
 
 struct rswitch_private {

--- a/drivers/net/ethernet/renesas/rswitch.h
+++ b/drivers/net/ethernet/renesas/rswitch.h
@@ -216,7 +216,7 @@ struct rswitch_gwca_chain {
 #define RSWITCH_MAX_CTAG_PCP	7
 #define MAX_MTU_SZ		9000
 #define MAX_DESC_SZ		2048
-#define VMQ_INFO_VERSION	1
+#define VMQ_INFO_VERSION	2
 
 struct rswitch_gwca_ts_info {
 	struct sk_buff *skb;
@@ -289,6 +289,7 @@ struct rswitch_vmq_status {
 	u64 back_tx, back_rx;
 	u64 tx_front_ring_size, rx_front_ring_size;
 	u64 tx_back_ring_size, rx_back_ring_size;
+	bool scheduled_tx;
 };
 
 struct rswitch_device {

--- a/drivers/net/ethernet/renesas/rswitch_xenback.c
+++ b/drivers/net/ethernet/renesas/rswitch_xenback.c
@@ -362,8 +362,10 @@ void rswitch_vmq_back_data_irq(struct rswitch_gwca_chain *c)
 {
 	struct rswitch_vmq_back_info *be = c->back_info;
 
-	notify_remote_via_irq(be->rx_irq);
-	notify_remote_via_irq(be->tx_irq);
+	if (!c->dir_tx)
+		notify_remote_via_irq(be->rx_irq);
+	else
+		notify_remote_via_irq(be->tx_irq);
 }
 
 static irqreturn_t rswitch_vmq_back_rx_interrupt(int irq, void *dev_id)

--- a/drivers/net/ethernet/renesas/rswitch_xenback.c
+++ b/drivers/net/ethernet/renesas/rswitch_xenback.c
@@ -55,7 +55,7 @@ struct rswitch_vmq_back_info {
 /* Optimal value to periodically trigger of DomU TX chain */
 static int tx_trigger_time_nsec = 200 * 1000;
 /* Optimal value between performance and event numbers for front devices */
-static u16 chain_irq_delay = 0x100;
+static u16 chain_irq_delay = 0x40;
 module_param(chain_irq_delay, ushort, 0);
 MODULE_PARM_DESC(chain_irq_delay,
 		 "Set IRQ status delay for VMQ device RX chain in range 0-0xfff");

--- a/drivers/net/ethernet/renesas/rswitch_xenback.c
+++ b/drivers/net/ethernet/renesas/rswitch_xenback.c
@@ -82,6 +82,9 @@ rswitch_vmq_back_ndev_register(struct rswitch_private *priv, int index)
 	spin_lock_init(&rdev->lock);
 
 	INIT_LIST_HEAD(&rdev->routing_list);
+#if IS_ENABLED(CONFIG_IP_MROUTE)
+	INIT_LIST_HEAD(&rdev->mult_routing_list);
+#endif
 
 	ndev->features = NETIF_F_RXCSUM;
 	ndev->hw_features = NETIF_F_RXCSUM;

--- a/drivers/net/ethernet/renesas/rswitch_xenback.c
+++ b/drivers/net/ethernet/renesas/rswitch_xenback.c
@@ -256,6 +256,7 @@ static int rswitch_vmq_back_probe(struct xenbus_device *dev,
 
 		be->type = RSWITCH_PV_TSN;
 		netif_dormant_on(rdev->ndev);
+		be->rdev = rdev;
 	} else {
 		xenbus_dev_fatal(dev, err, "Unknown device type: %s ", type_str);
 		err = -ENODEV;

--- a/drivers/net/ethernet/renesas/rswitch_xenback.c
+++ b/drivers/net/ethernet/renesas/rswitch_xenback.c
@@ -58,7 +58,7 @@ static int tx_trigger_time_nsec = 200 * 1000;
 static u16 chain_irq_delay = 0x100;
 module_param(chain_irq_delay, ushort, 0);
 MODULE_PARM_DESC(chain_irq_delay,
-		 "Set IRQ status delay for VMQ device RX/TX chains in range 0-0xfff");
+		 "Set IRQ status delay for VMQ device RX chain in range 0-0xfff");
 
 static struct rswitch_device*
 rswitch_vmq_back_ndev_register(struct rswitch_private *priv, int index)
@@ -251,7 +251,7 @@ static int rswitch_vmq_back_probe(struct xenbus_device *dev,
 					 err);
 			goto fail;
 		}
-		rswitch_gwca_chain_set_irq_delay(priv, be->tx_chain, chain_irq_delay);
+		rswitch_gwca_chain_set_irq_delay(priv, be->tx_chain, 0);
 		rswitch_gwca_chain_set_irq_delay(priv, be->rx_chain, chain_irq_delay);
 	}
 	else if (strcmp(type_str, "tsn") == 0) {

--- a/drivers/net/ethernet/renesas/rswitch_xenback.c
+++ b/drivers/net/ethernet/renesas/rswitch_xenback.c
@@ -76,7 +76,7 @@ rswitch_vmq_back_ndev_register(struct rswitch_private *priv, int index)
 	rdev->port = priv->gwca.index;
 	rdev->etha = NULL;
 	rdev->remote_chain = -1;
-
+	rdev->rdev_type = RSWITCH_VMQ_BACK_DEV;
 	rdev->addr = priv->addr;
 
 	spin_lock_init(&rdev->lock);

--- a/drivers/net/ethernet/renesas/rswitch_xenfront.c
+++ b/drivers/net/ethernet/renesas/rswitch_xenfront.c
@@ -318,6 +318,7 @@ static int rswitch_vmq_front_connect(struct net_device *dev)
 		WRITE_ONCE(rdev->vmq_info->front_rx, 0);
 		WRITE_ONCE(rdev->vmq_info->tx_front_ring_size, RX_RING_SIZE);
 		WRITE_ONCE(rdev->vmq_info->rx_front_ring_size, TX_RING_SIZE);
+		WRITE_ONCE(rdev->vmq_info->scheduled_tx, false);
 
 		err = xenbus_printf(XBT_NIL, np->xbdev->nodename, "gref",
 				    "%u", np->gref);

--- a/drivers/net/ethernet/renesas/rswitch_xenfront.c
+++ b/drivers/net/ethernet/renesas/rswitch_xenfront.c
@@ -111,10 +111,13 @@ static int rswitch_vmq_front_ndev_register(struct rswitch_device *rdev,
 
 	snprintf(ndev->name, IFNAMSIZ, "%s%d", type, index);
 
-	if (strcmp(type, "tsn") == 0)
+	if (strcmp(type, "tsn") == 0) {
 		rdev->port = index;
-	else
+		rdev->rdev_type = RSWITCH_TSN_DEV;
+	} else {
+		rdev->rdev_type = RSWITCH_VMQ_FRONT_DEV;
 		rdev->port = rdev->priv->gwca.index;
+	}
 
 	netif_napi_add(ndev, &rdev->napi, rswitch_poll, 64);
 


### PR DESCRIPTION
This PR contains patches with fixes and optimizations of VMQ performance. Mainly, these changes introduce mechanisms to avoid package losses, reduce the number of Xen events to DomD, and as a result improve bandwidth.
Currently, the iperf tests are as follows:
- Default MTU (1500):
- - To host:
- - - (TCP)
iperf3 -c 192.168.1.100 -t 10 -b 0 -M 8134: 440 Mbits/sec
iperf3 -c 192.168.1.100 -t 10 -b 0 -M 8134 -R: 348 Mbits/sec
- - - (UDP)
iperf3 -c 192.168.1.100 -t 10 -u -b 0: 411 Mbits/sec
iperf3 -c 192.168.1.100 -t 10 -u -b 0 -R: 511 Mbits/sec
- - To VMQ:
- - - (TCP)
iperf3 -c 192.168.5.1 -t 10 -b 0 -M 8134: 744 Mbits/sec
iperf3 -c 192.168.5.1 -t 10 -b 0 -M 8134 -R: 907 Mbits/sec
- - - (UDP)
iperf3 -c 192.168.5.1 -t 10 -u -b 0: 425 Mbits/sec
iperf3 -c 192.168.5.1 -t 10 -u -b 0 -R: 881 Mbits/sec
- 9000 MTU:
- - To host:
- - - (TCP)
iperf3 -c 192.168.1.100 -t 10 -b 0 -M 8134: 731 Mbits/sec
iperf3 -c 192.168.1.100 -t 10 -b 0 -M 8134 -R: 700 Mbits/sec
- - - (UDP)
iperf3 -c 192.168.1.100 -t 10 -u -b 0 -l 8134: 637 Mbits/sec
iperf3 -c 192.168.1.100 -t 10 -u -b 0 -l 8134 -R: 783 Mbits/sec
- - To VMQ:
- - - (TCP)
iperf3 -c 192.168.5.1 -t 10 -b 0 -M 8134: 1.37 Gbits/sec
iperf3 -c 192.168.5.1 -t 10 -b 0 -M 8134 -R: 1.37 Gbits/sec
- - - (UDP)
iperf3 -c 192.168.5.1 -t 10 -u -b 0 -l 8134: 635 Mbits/sec
iperf3 -c 192.168.5.1 -t 10 -u -b 0 -l 8134 -R: 1.76 Gbits/sec


**With optimizations:**
- Default MTU (1500):
- - To host:
- - - (TCP)
iperf3 -c 192.168.1.100 -t 10 -b 0 -M 8134: 495 Mbits/sec (**+12.5%**)
iperf3 -c 192.168.1.100 -t 10 -b 0 -M 8134 -R: 583 Mbits/sec (**+67.5%**)
- - - (UDP)
iperf3 -c 192.168.1.100 -t 10 -u -b 0: 867 Mbits/sec (**+109.5%**)
iperf3 -c 192.168.1.100 -t 10 -u -b 0 -R: 891 Mbits/sec (**+74%**)
- - To VMQ:
- - - (TCP)
iperf3 -c 192.168.5.1 -t 10 -b 0 -M 8134: 894 Mbits/sec (**+20%**)
iperf3 -c 192.168.5.1 -t 10 -b 0 -M 8134 -R: 1.06 Gbits/sec (**+20%**)
- - - (UDP)
iperf3 -c 192.168.5.1 -t 10 -u -b 0: 943 Mbits/sec (**+122%**)
iperf3 -c 192.168.5.1 -t 10 -u -b 0 -R: 881 Mbits/sec (**+72.5%**)
- 9000 MTU:
- - To host:
- - - (TCP)
iperf3 -c 192.168.1.100 -t 10 -b 0 -M 8134: 764 Mbits/sec (**+4.5%**)
iperf3 -c 192.168.1.100 -t 10 -b 0 -M 8134 -R: 875 Mbits/sec (**+25%**)
- - - (UDP)
iperf3 -c 192.168.1.100 -t 10 -u -b 0 -l 8134: 958 Mbits/sec (**+50%**)
iperf3 -c 192.168.1.100 -t 10 -u -b 0 -l 8134 -R: 992 Mbits/sec (**+26.5%**)
- - To VMQ:
- - - (TCP)
iperf3 -c 192.168.5.1 -t 10 -b 0 -M 8134: 1.57 Gbits/sec (**+14.5%**)
iperf3 -c 192.168.5.1 -t 10 -b 0 -M 8134 -R: 1.52 Gbits/sec (**+11%**)
- - - (UDP)
iperf3 -c 192.168.5.1 -t 10 -u -b 0 -l 8134: 1.78 Gbits/sec (**+187%**)
iperf3 -c 192.168.5.1 -t 10 -u -b 0 -l 8134 -R: 1.78 Gbits/sec (**+- the same**)

**Checkpatch output**:
git diff HEAD~10 --patch | scripts/checkpatch.pl
total: 0 errors, 0 warnings, 0 checks, 638 lines checked

Your patch has no obvious style problems and is ready for submission.