### PR TITLE
Merge patches from meta-xt-vhost

### DIFF
--- a/drivers/vhost/Kconfig
+++ b/drivers/vhost/Kconfig
@@ -6,6 +6,11 @@ config VHOST_IOTLB
 	  This option is selected by any driver which needs to support
 	  an IOMMU in software.
 
+config VHOST_XEN
+	tristate
+	help
+	  Support of Xen grant mappings for accessing descriptors in virtio rings.
+
 config VHOST_RING
 	tristate
 	select VHOST_IOTLB
@@ -16,6 +21,7 @@ config VHOST_RING
 config VHOST
 	tristate
 	select VHOST_IOTLB
+	select VHOST_XEN if XEN
 	help
 	  This option is selected by any driver which needs to access
 	  the core of vhost.

--- a/drivers/vhost/Kconfig
+++ b/drivers/vhost/Kconfig
@@ -9,7 +9,7 @@ config VHOST_IOTLB
 config VHOST_XEN
 	tristate
 	help
-	  Support of Xen grant mappings for accessing descriptors in virtio rings.
+	  Support of Xen specific mappings for accessing descriptors in virtio rings.
 
 config VHOST_RING
 	tristate

--- a/drivers/vhost/Makefile
+++ b/drivers/vhost/Makefile
@@ -17,3 +17,6 @@ obj-$(CONFIG_VHOST)	+= vhost.o
 
 obj-$(CONFIG_VHOST_IOTLB) += vhost_iotlb.o
 vhost_iotlb-y := iotlb.o
+
+obj-$(CONFIG_VHOST_XEN) += vhost_xen.o
+vhost_xen-y := xen.o

--- a/drivers/vhost/net.c
+++ b/drivers/vhost/net.c
@@ -148,6 +148,27 @@ struct vhost_net {
 
 static unsigned vhost_net_zcopy_mask __read_mostly;
 
+#ifdef CONFIG_VHOST_XEN
+static void vhost_net_unmap_desc(struct vhost_virtqueue *vq, int count)
+{
+	int i;
+
+	for (i = 0; i < count; i++) {
+		if (vq->iov[i].iov_base)
+			vhost_xen_unmap_desc(vq, vq->iov[i].iov_base, vq->iov[i].iov_len);
+	}
+
+	/*
+	 * Alternatively we could unmap *all* mapped at this point descriptors
+	 * (including indirect) in one go instead of unmapping one by one.
+	 * But we must be sure that doing that we won't end up unmapping
+	 * descriptors which are still in use. This depends on the place(s)
+	 * from which current function gets called.
+	 */
+	/*vhost_xen_unmap_desc_all(vq);*/
+}
+#endif
+
 static void *vhost_net_buf_get_ptr(struct vhost_net_buf *rxq)
 {
 	if (rxq->tail != rxq->head)
@@ -599,7 +620,11 @@ static size_t init_iov_iter(struct vhost_virtqueue *vq, struct iov_iter *iter,
 	/* Skip header. TODO: support TSO. */
 	size_t len = iov_length(vq->iov, out);
 
+#ifdef CONFIG_VHOST_XEN
+	iov_iter_kvec(iter, WRITE, (struct kvec *)vq->iov, out, len);
+#else
 	iov_iter_init(iter, WRITE, vq->iov, out, len);
+#endif
 	iov_iter_advance(iter, hdr_size);
 
 	return iov_iter_count(iter);
@@ -841,6 +866,11 @@ done:
 		vq->heads[nvq->done_idx].id = cpu_to_vhost32(vq, head);
 		vq->heads[nvq->done_idx].len = 0;
 		++nvq->done_idx;
+
+#ifdef CONFIG_VHOST_XEN
+		/* Descriptors must be unmapped as soon as they are not used */
+		vhost_net_unmap_desc(vq, out);
+#endif
 	} while (likely(!vhost_exceeds_weight(vq, ++sent_pkts, total_len)));
 
 	vhost_tx_batch(net, nvq, sock, &msg);
@@ -1173,14 +1203,22 @@ static void handle_rx(struct vhost_net *net)
 			msg.msg_control = vhost_net_buf_consume(&nvq->rxq);
 		/* On overrun, truncate and discard */
 		if (unlikely(headcount > UIO_MAXIOV)) {
+#ifdef CONFIG_VHOST_XEN
+			iov_iter_kvec(&msg.msg_iter, READ, (struct kvec *)vq->iov, 1, 1);
+#else
 			iov_iter_init(&msg.msg_iter, READ, vq->iov, 1, 1);
+#endif
 			err = sock->ops->recvmsg(sock, &msg,
 						 1, MSG_DONTWAIT | MSG_TRUNC);
 			pr_debug("Discarded rx packet: len %zd\n", sock_len);
 			continue;
 		}
 		/* We don't need to be notified again. */
+#ifdef CONFIG_VHOST_XEN
+		iov_iter_kvec(&msg.msg_iter, READ, (struct kvec *)vq->iov, in, vhost_len);
+#else
 		iov_iter_init(&msg.msg_iter, READ, vq->iov, in, vhost_len);
+#endif
 		fixup = msg.msg_iter;
 		if (unlikely((vhost_hlen))) {
 			/* We will supply the header ourselves
@@ -1224,6 +1262,10 @@ static void handle_rx(struct vhost_net *net)
 			goto out;
 		}
 		nvq->done_idx += headcount;
+#ifdef CONFIG_VHOST_XEN
+		/* Descriptors must be unmapped as soon as they are not used */
+		vhost_net_unmap_desc(vq, in);
+#endif
 		if (nvq->done_idx > VHOST_NET_BATCH)
 			vhost_net_signal_used(nvq);
 		if (unlikely(vq_log))

--- a/drivers/vhost/vhost.c
+++ b/drivers/vhost/vhost.c
@@ -501,6 +501,9 @@ void vhost_dev_init(struct vhost_dev *dev,
 		vq->heads = NULL;
 		vq->dev = dev;
 		mutex_init(&vq->mutex);
+#ifdef CONFIG_VHOST_XEN
+		INIT_LIST_HEAD(&vq->desc_maps);
+#endif
 		vhost_vq_reset(dev, vq);
 		if (vq->handle_kick)
 			vhost_poll_init(&vq->poll, vq->handle_kick,
@@ -700,6 +703,9 @@ void vhost_dev_cleanup(struct vhost_dev *dev)
 		if (dev->vqs[i]->call_ctx.ctx)
 			eventfd_ctx_put(dev->vqs[i]->call_ctx.ctx);
 		vhost_vq_reset(dev, dev->vqs[i]);
+#ifdef CONFIG_VHOST_XEN
+		vhost_xen_unmap_desc_all(dev->vqs[i]);
+#endif
 	}
 	vhost_dev_free_iovecs(dev);
 	if (dev->log_ctx)
@@ -1445,6 +1451,14 @@ static long vhost_set_memory(struct vhost_dev *d, struct vhost_memory __user *m)
 	for (region = newmem->regions;
 	     region < newmem->regions + mem.nregions;
 	     region++) {
+
+#ifdef CONFIG_VHOST_XEN
+		if (region->guest_phys_addr & XEN_GRANT_DMA_ADDR_OFF) {
+			pr_err("%s: Skip pseudo memory region for Xen grant mappings\n", __func__);
+			continue;
+		}
+#endif
+
 		if (vhost_iotlb_add_range(newumem,
 					  region->guest_phys_addr,
 					  region->guest_phys_addr +
@@ -2038,6 +2052,15 @@ static int translate_desc(struct vhost_virtqueue *vq, u64 addr, u32 len,
 	u64 s = 0;
 	int ret = 0;
 
+#ifdef CONFIG_VHOST_XEN
+	iov->iov_len = len;
+	iov->iov_base = vhost_xen_map_desc(vq, addr, len, access);
+	if (IS_ERR(iov->iov_base))
+		return PTR_ERR(iov->iov_base);
+	else
+		return 1;
+#endif
+
 	while ((u64)len > s) {
 		u64 size;
 		if (unlikely(ret >= iov_size)) {
@@ -2117,7 +2140,12 @@ static int get_indirect(struct vhost_virtqueue *vq,
 			vq_err(vq, "Translation failure %d in indirect.\n", ret);
 		return ret;
 	}
+
+#ifdef CONFIG_VHOST_XEN
+	iov_iter_kvec(&from, READ, (struct kvec *)vq->indirect, ret, len);
+#else
 	iov_iter_init(&from, READ, vq->indirect, ret, len);
+#endif
 	count = len / sizeof desc;
 	/* Buffers are chained via a 16 bit next field, so
 	 * we can have at most 2^16 of these. */
@@ -2179,6 +2207,12 @@ static int get_indirect(struct vhost_virtqueue *vq,
 			*out_num += ret;
 		}
 	} while ((i = next_desc(vq, &desc)) != -1);
+
+#ifdef CONFIG_VHOST_XEN
+	if (vq->indirect)
+		vhost_xen_unmap_desc(vq, vq->indirect->iov_base, vq->indirect->iov_len);
+#endif
+
 	return 0;
 }
 

--- a/drivers/vhost/vhost.h
+++ b/drivers/vhost/vhost.h
@@ -135,7 +135,7 @@ struct vhost_virtqueue {
 
 #ifdef CONFIG_VHOST_XEN
 	/*
-	 * Contains virtio descriptors mapped by using Xen grant mappings
+	 * Contains virtio descriptors mapped by using Xen specific mappings
 	 * in order to handle current request. To be unmapped once the request
 	 * is processed.
 	 */

--- a/drivers/vhost/vhost.h
+++ b/drivers/vhost/vhost.h
@@ -132,6 +132,15 @@ struct vhost_virtqueue {
 	bool user_be;
 #endif
 	u32 busyloop_timeout;
+
+#ifdef CONFIG_VHOST_XEN
+	/*
+	 * Contains virtio descriptors mapped by using Xen grant mappings
+	 * in order to handle current request. To be unmapped once the request
+	 * is processed.
+	 */
+	struct list_head desc_maps;
+#endif
 };
 
 struct vhost_msg_node {
@@ -227,6 +236,24 @@ int vhost_init_device_iotlb(struct vhost_dev *d, bool enabled);
 
 void vhost_iotlb_map_free(struct vhost_iotlb *iotlb,
 			  struct vhost_iotlb_map *map);
+
+#define XEN_GRANT_DMA_ADDR_OFF    (1ULL << 63)
+
+#ifdef CONFIG_VHOST_XEN
+void vhost_xen_unmap_desc(struct vhost_virtqueue *vq, void *ptr, u32 size);
+void vhost_xen_unmap_desc_all(struct vhost_virtqueue *vq);
+void *vhost_xen_map_desc(struct vhost_virtqueue *vq, u64 addr, u32 size,
+		int access);
+#else
+static inline void vhost_xen_unmap_desc(struct vhost_virtqueue *vq,
+		void *ptr, u32 size) { }
+static inline void vhost_xen_unmap_desc_all(struct vhost_virtqueue *vq) { }
+static inline void *vhost_xen_map_desc(struct vhost_virtqueue *vq,
+		u64 addr, u32 size, int access)
+{
+	return ERR_PTR(-ENODEV);
+}
+#endif
 
 #define vq_err(vq, fmt, ...) do {                                  \
 		pr_debug(pr_fmt(fmt), ##__VA_ARGS__);       \

--- a/drivers/vhost/vsock.c
+++ b/drivers/vhost/vsock.c
@@ -80,6 +80,27 @@ static struct vhost_vsock *vhost_vsock_get(u32 guest_cid)
 	return NULL;
 }
 
+#ifdef CONFIG_VHOST_XEN
+static void vhost_vsock_unmap_desc(struct vhost_virtqueue *vq, int count)
+{
+	int i;
+
+	for (i = 0; i < count; i++) {
+		if (vq->iov[i].iov_base)
+			vhost_xen_unmap_desc(vq, vq->iov[i].iov_base, vq->iov[i].iov_len);
+	}
+
+	/*
+	 * Alternatively we could unmap *all* mapped at this point descriptors
+	 * (including indirect) in one go instead of unmapping one by one.
+	 * But we must be sure that doing that we won't end up unmapping
+	 * descriptors which are still in use. This depends on the place(s)
+	 * from which current function gets called.
+	 */
+	/*vhost_xen_unmap_desc_all(vq);*/
+}
+#endif
+
 static void
 vhost_transport_do_send_pkt(struct vhost_vsock *vsock,
 			    struct vhost_virtqueue *vq)
@@ -154,7 +175,11 @@ vhost_transport_do_send_pkt(struct vhost_vsock *vsock,
 			break;
 		}
 
+#ifdef CONFIG_VHOST_XEN
+		iov_iter_kvec(&iov_iter, READ, (struct kvec *)&vq->iov[out], in, iov_len);
+#else
 		iov_iter_init(&iov_iter, READ, &vq->iov[out], in, iov_len);
+#endif
 		payload_len = pkt->len - pkt->off;
 
 		/* If the packet is greater than the space available in the
@@ -186,6 +211,10 @@ vhost_transport_do_send_pkt(struct vhost_vsock *vsock,
 		 */
 		virtio_transport_deliver_tap_pkt(pkt);
 
+#ifdef CONFIG_VHOST_XEN
+		/* Descriptors must be unmapped as soon as they are not used */
+		vhost_vsock_unmap_desc(vq, out + in);
+#endif
 		vhost_add_used(vq, head, sizeof(pkt->hdr) + payload_len);
 		added = true;
 
@@ -336,7 +365,11 @@ vhost_vsock_alloc_pkt(struct vhost_virtqueue *vq,
 		return NULL;
 
 	len = iov_length(vq->iov, out);
+#ifdef CONFIG_VHOST_XEN
+	iov_iter_kvec(&iov_iter, WRITE, (struct kvec *)vq->iov, out, len);
+#else
 	iov_iter_init(&iov_iter, WRITE, vq->iov, out, len);
+#endif
 
 	nbytes = copy_from_iter(&pkt->hdr, sizeof(pkt->hdr), &iov_iter);
 	if (nbytes != sizeof(pkt->hdr)) {
@@ -493,6 +526,10 @@ static void vhost_vsock_handle_tx_kick(struct vhost_work *work)
 		else
 			virtio_transport_free_pkt(pkt);
 
+#ifdef CONFIG_VHOST_XEN
+		/* Descriptors must be unmapped as soon as they are not used */
+		vhost_vsock_unmap_desc(vq, out + in);
+#endif
 		len += sizeof(pkt->hdr);
 		vhost_add_used(vq, head, len);
 		total_len += len;

--- a/drivers/vhost/xen.c
+++ b/drivers/vhost/xen.c
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * A specific module for accessing descriptors in virtio rings which contain
+ * guest grant based addresses instead of pseudo-physical addresses.
+ * Please see Xen grant DMA-mapping layer at drivers/xen/grant-dma-ops.c
+ * which is the origin of such mapping scheme.
+ *
+ * Copyright (C) 2023 EPAM Systems Inc.
+ */
+
+#include <linux/module.h>
+#include <linux/slab.h>
+#include <linux/vhost.h>
+#include <xen/grant_table.h>
+#include <xen/xen.h>
+
+#include "vhost.h"
+
+/* TODO: Make it possible to get domid */
+static domid_t guest_domid = 2;
+
+struct vhost_xen_grant_map {
+	struct list_head next;
+	int count;
+	int flags;
+	grant_ref_t *grefs;
+	domid_t domid;
+	struct gnttab_map_grant_ref *map_ops;
+	struct gnttab_unmap_grant_ref *unmap_ops;
+	struct page **pages;
+	unsigned long vaddr;
+};
+
+static void vhost_xen_free_map(struct vhost_xen_grant_map *map)
+{
+	if (!map)
+		return;
+
+	if (map->pages)
+		gnttab_free_pages(map->count, map->pages);
+
+	kvfree(map->pages);
+	kvfree(map->grefs);
+	kvfree(map->map_ops);
+	kvfree(map->unmap_ops);
+	kfree(map);
+}
+
+static struct vhost_xen_grant_map *vhost_xen_alloc_map(int count)
+{
+	struct vhost_xen_grant_map *map;
+	int i;
+
+	map = kzalloc(sizeof(*map), GFP_KERNEL);
+	if (!map)
+		return NULL;
+
+	map->grefs = kvcalloc(count, sizeof(map->grefs[0]), GFP_KERNEL);
+	map->map_ops = kvcalloc(count, sizeof(map->map_ops[0]), GFP_KERNEL);
+	map->unmap_ops = kvcalloc(count, sizeof(map->unmap_ops[0]), GFP_KERNEL);
+	map->pages = kvcalloc(count, sizeof(map->pages[0]), GFP_KERNEL);
+	if (!map->grefs || !map->map_ops || !map->unmap_ops || !map->pages)
+		goto err;
+
+	if (gnttab_alloc_pages(count, map->pages))
+		goto err;
+
+	for (i = 0; i < count; i++) {
+		map->map_ops[i].handle = -1;
+		map->unmap_ops[i].handle = -1;
+	}
+
+	map->count = count;
+
+	return map;
+
+err:
+	vhost_xen_free_map(map);
+
+	return NULL;
+}
+
+static int vhost_xen_map_pages(struct vhost_xen_grant_map *map)
+{
+	int i, ret = 0;
+
+	if (map->map_ops[0].handle != -1)
+		return -EINVAL;
+
+	for (i = 0; i < map->count; i++) {
+		unsigned long vaddr = (unsigned long)
+			pfn_to_kaddr(page_to_xen_pfn(map->pages[i]));
+		gnttab_set_map_op(&map->map_ops[i], vaddr, map->flags,
+			map->grefs[i], map->domid);
+		gnttab_set_unmap_op(&map->unmap_ops[i], vaddr, map->flags, -1);
+	}
+
+	ret = gnttab_map_refs(map->map_ops, NULL, map->pages, map->count);
+	for (i = 0; i < map->count; i++) {
+		if (map->map_ops[i].status == GNTST_okay)
+			map->unmap_ops[i].handle = map->map_ops[i].handle;
+		else if (!ret)
+			ret = -EINVAL;
+	}
+
+	return ret;
+}
+
+static int vhost_xen_unmap_pages(struct vhost_xen_grant_map *map)
+{
+	int i, ret;
+
+	if (map->unmap_ops[0].handle == -1)
+		return -EINVAL;
+
+	ret = gnttab_unmap_refs(map->unmap_ops, NULL, map->pages, map->count);
+	if (ret)
+		return ret;
+
+	for (i = 0; i < map->count; i++) {
+		if (map->unmap_ops[i].status != GNTST_okay)
+			ret = -EINVAL;
+		map->unmap_ops[i].handle = -1;
+	}
+
+	return ret;
+}
+
+static void vhost_xen_put_map(struct vhost_xen_grant_map *map)
+{
+	if (!map)
+		return;
+
+	if (map->vaddr) {
+		if (map->count > 1)
+			vunmap((void *)map->vaddr);
+		map->vaddr = 0;
+	}
+
+	if (map->pages) {
+		int ret;
+
+		ret = vhost_xen_unmap_pages(map);
+		if (ret)
+			pr_err("%s: Failed to unmap pages from dom%d (ret=%d)\n",
+					__func__, map->domid, ret);
+	}
+	vhost_xen_free_map(map);
+}
+
+static struct vhost_xen_grant_map *vhost_xen_find_map(struct vhost_virtqueue *vq,
+		unsigned long vaddr, int count)
+{
+	struct vhost_xen_grant_map *map;
+
+	list_for_each_entry(map, &vq->desc_maps, next) {
+		if (map->vaddr != vaddr)
+			continue;
+		if (count && map->count != count)
+			continue;
+		return map;
+	}
+
+	return NULL;
+}
+
+void vhost_xen_unmap_desc_all(struct vhost_virtqueue *vq)
+{
+	struct vhost_xen_grant_map *map;
+
+	if (!xen_domain())
+		return;
+
+	while (!list_empty(&vq->desc_maps)) {
+		map = list_entry(vq->desc_maps.next, struct vhost_xen_grant_map, next);
+		list_del(&map->next);
+
+		pr_debug("%s: dom%d: vaddr 0x%lx count %u\n",
+				__func__, map->domid, map->vaddr, map->count);
+		vhost_xen_put_map(map);
+	}
+}
+
+void *vhost_xen_map_desc(struct vhost_virtqueue *vq, u64 addr, u32 size, int access)
+{
+	struct vhost_xen_grant_map *map;
+	unsigned long offset = xen_offset_in_page(addr);
+	int count = XEN_PFN_UP(offset + size);
+	int i, ret;
+
+	if (!xen_domain() || guest_domid == DOMID_INVALID)
+		return ERR_PTR(-ENODEV);
+
+	if (!(addr & XEN_GRANT_DMA_ADDR_OFF)) {
+		pr_err("%s: Descriptor from dom%d cannot be mapped (0x%llx is not a Xen grant address)\n",
+				__func__, guest_domid, addr);
+		return ERR_PTR(-EINVAL);
+	}
+
+	map = vhost_xen_alloc_map(count);
+	if (!map)
+		return ERR_PTR(-ENOMEM);
+
+	map->domid = guest_domid;
+	for (i = 0; i < count; i++)
+		map->grefs[i] = ((addr & ~XEN_GRANT_DMA_ADDR_OFF) >> XEN_PAGE_SHIFT) + i;
+
+	map->flags |= GNTMAP_host_map;
+	if (access == VHOST_ACCESS_RO)
+		map->flags |= GNTMAP_readonly;
+
+	ret = vhost_xen_map_pages(map);
+	if (ret) {
+		pr_err("%s: Failed to map pages from dom%d (ret=%d)\n",
+				__func__, map->domid, ret);
+		vhost_xen_put_map(map);
+		return ERR_PTR(ret);
+	}
+
+	/*
+	 * Consider allocating xen_alloc_unpopulated_contiguous_pages() instead of
+	 * xen_alloc_unpopulated_pages() to avoid maping as with the later
+	 * map->pages are not guaranteed to be contiguous.
+	 */
+	if (map->count > 1) {
+		map->vaddr = (unsigned long)vmap(map->pages, map->count, VM_MAP,
+				PAGE_KERNEL);
+		if (!map->vaddr) {
+			pr_err("%s: Failed to create virtual mappings\n", __func__);
+			vhost_xen_put_map(map);
+			return ERR_PTR(-ENOMEM);
+		}
+	} else
+		map->vaddr = (unsigned long)pfn_to_kaddr(page_to_xen_pfn(map->pages[0]));
+
+	list_add_tail(&map->next, &vq->desc_maps);
+
+	pr_debug("%s: dom%d: addr 0x%llx size 0x%x (access 0x%x) -> vaddr 0x%lx count %u (paddr 0x%llx)\n",
+			__func__, map->domid, addr, size, access, map->vaddr, count,
+			page_to_phys(map->pages[0]));
+
+	return (void *)(map->vaddr + offset);
+}
+
+void vhost_xen_unmap_desc(struct vhost_virtqueue *vq, void *ptr, u32 size)
+{
+	struct vhost_xen_grant_map *map;
+	unsigned long offset = xen_offset_in_page(ptr);
+	int count = XEN_PFN_UP(offset + size);
+
+	if (!xen_domain())
+		return;
+
+	map = vhost_xen_find_map(vq, (unsigned long)ptr & XEN_PAGE_MASK, count);
+	if (map) {
+		list_del(&map->next);
+
+		pr_debug("%s: dom%d: vaddr 0x%lx count %u\n",
+				__func__, map->domid, map->vaddr, map->count);
+		vhost_xen_put_map(map);
+	}
+}
+
+static int __init vhost_xen_init(void)
+{
+	if (!xen_domain())
+		return -ENODEV;
+
+	pr_info("%s: Initialize module for Xen grant mappings\n", __func__);
+
+	return 0;
+}
+
+static void __exit vhost_xen_exit(void)
+{
+
+}
+
+module_init(vhost_xen_init);
+module_exit(vhost_xen_exit);
+
+MODULE_DESCRIPTION("Xen grant mappings module for vhost");
+MODULE_AUTHOR("Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>");
+MODULE_LICENSE("GPL v2");

--- a/drivers/vhost/xen.c
+++ b/drivers/vhost/xen.c
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
  * A specific module for accessing descriptors in virtio rings which contain
- * guest grant based addresses instead of pseudo-physical addresses.
+ * either usual guest pseudo-physical addresses or guest grant based addresses.
+ * Depending on the descriptor's nature we use either Xen foreign mappings or
+ * Xen grant mappings to map/unmap an underlying guest page.
  * Please see Xen grant DMA-mapping layer at drivers/xen/grant-dma-ops.c
- * which is the origin of such mapping scheme.
+ * which is the origin of Xen grant mappings scheme.
  *
  * Copyright (C) 2023 EPAM Systems Inc.
  */
@@ -14,24 +16,36 @@
 #include <xen/grant_table.h>
 #include <xen/xen.h>
 #include <xen/xenbus.h>
+#include <xen/interface/memory.h>
+#include <asm/xen/hypercall.h>
 
 #include "vhost.h"
 
 static domid_t guest_domid = DOMID_INVALID;
 
-struct vhost_xen_grant_map {
+static bool nogrant;
+module_param(nogrant, bool, 0444);
+MODULE_PARM_DESC(nogrant, "Disable Xen grant mappings");
+
+struct vhost_xen_map {
 	struct list_head next;
 	int count;
-	int flags;
-	grant_ref_t *grefs;
+	grant_handle_t *handles;
 	domid_t domid;
-	struct gnttab_map_grant_ref *map_ops;
-	struct gnttab_unmap_grant_ref *unmap_ops;
 	struct page **pages;
 	unsigned long vaddr;
 };
 
-static void vhost_xen_free_map(struct vhost_xen_grant_map *map)
+struct vhost_xen_ops {
+	struct vhost_xen_map *(*alloc_map)(int count);
+	void (*free_map)(struct vhost_xen_map *map);
+	int (*map_pages)(struct vhost_xen_map *map, u64 gpaddr, bool readonly);
+	int (*unmap_pages)(struct vhost_xen_map *map);
+};
+
+static const struct vhost_xen_ops *vhost_xen_ops;
+
+static void vhost_xen_grant_free_map(struct vhost_xen_map *map)
 {
 	if (!map)
 		return;
@@ -40,93 +54,213 @@ static void vhost_xen_free_map(struct vhost_xen_grant_map *map)
 		gnttab_free_pages(map->count, map->pages);
 
 	kvfree(map->pages);
-	kvfree(map->grefs);
-	kvfree(map->map_ops);
-	kvfree(map->unmap_ops);
+	kvfree(map->handles);
 	kfree(map);
 }
 
-static struct vhost_xen_grant_map *vhost_xen_alloc_map(int count)
+static struct vhost_xen_map *vhost_xen_grant_alloc_map(int count)
 {
-	struct vhost_xen_grant_map *map;
-	int i;
+	struct vhost_xen_map *map;
 
 	map = kzalloc(sizeof(*map), GFP_KERNEL);
 	if (!map)
 		return NULL;
 
-	map->grefs = kvcalloc(count, sizeof(map->grefs[0]), GFP_KERNEL);
-	map->map_ops = kvcalloc(count, sizeof(map->map_ops[0]), GFP_KERNEL);
-	map->unmap_ops = kvcalloc(count, sizeof(map->unmap_ops[0]), GFP_KERNEL);
+	map->handles = kvcalloc(count, sizeof(map->handles[0]), GFP_KERNEL);
 	map->pages = kvcalloc(count, sizeof(map->pages[0]), GFP_KERNEL);
-	if (!map->grefs || !map->map_ops || !map->unmap_ops || !map->pages)
+	if (!map->handles || !map->pages)
 		goto err;
 
 	if (gnttab_alloc_pages(count, map->pages))
 		goto err;
-
-	for (i = 0; i < count; i++) {
-		map->map_ops[i].handle = -1;
-		map->unmap_ops[i].handle = -1;
-	}
 
 	map->count = count;
 
 	return map;
 
 err:
-	vhost_xen_free_map(map);
+	vhost_xen_grant_free_map(map);
 
 	return NULL;
 }
 
-static int vhost_xen_map_pages(struct vhost_xen_grant_map *map)
+static int vhost_xen_grant_map_pages(struct vhost_xen_map *map, u64 gpaddr,
+		bool readonly)
 {
-	int i, ret = 0;
+	struct gnttab_map_grant_ref *map_ops;
+	int i, ret;
+	uint32_t flags = GNTMAP_host_map;
 
-	if (map->map_ops[0].handle != -1)
-		return -EINVAL;
+	map_ops = kvcalloc(map->count, sizeof(map_ops[0]), GFP_KERNEL);
+	if (!map_ops)
+		return -ENOMEM;
+
+	if (readonly)
+		flags |= GNTMAP_readonly;
 
 	for (i = 0; i < map->count; i++) {
 		unsigned long vaddr = (unsigned long)
 			pfn_to_kaddr(page_to_xen_pfn(map->pages[i]));
-		gnttab_set_map_op(&map->map_ops[i], vaddr, map->flags,
-			map->grefs[i], map->domid);
-		gnttab_set_unmap_op(&map->unmap_ops[i], vaddr, map->flags, -1);
+		grant_ref_t ref = XEN_PFN_DOWN(gpaddr & ~XEN_GRANT_DMA_ADDR_OFF) + i;
+
+		gnttab_set_map_op(&map_ops[i], vaddr, flags, ref, map->domid);
+		map->handles[i] = -1;
 	}
 
-	ret = gnttab_map_refs(map->map_ops, NULL, map->pages, map->count);
+	ret = gnttab_map_refs(map_ops, NULL, map->pages, map->count);
 	for (i = 0; i < map->count; i++) {
-		if (map->map_ops[i].status == GNTST_okay)
-			map->unmap_ops[i].handle = map->map_ops[i].handle;
+		if (map_ops[i].status == GNTST_okay)
+			map->handles[i] = map_ops[i].handle;
 		else if (!ret)
 			ret = -EINVAL;
 	}
 
+	kvfree(map_ops);
+
 	return ret;
 }
 
-static int vhost_xen_unmap_pages(struct vhost_xen_grant_map *map)
+static int vhost_xen_grant_unmap_pages(struct vhost_xen_map *map)
 {
+	struct gnttab_unmap_grant_ref *unmap_ops;
 	int i, ret;
 
-	if (map->unmap_ops[0].handle == -1)
-		return -EINVAL;
-
-	ret = gnttab_unmap_refs(map->unmap_ops, NULL, map->pages, map->count);
-	if (ret)
-		return ret;
+	unmap_ops = kvcalloc(map->count, sizeof(unmap_ops[0]), GFP_KERNEL);
+	if (!unmap_ops)
+		return -ENOMEM;
 
 	for (i = 0; i < map->count; i++) {
-		if (map->unmap_ops[i].status != GNTST_okay)
+		unsigned long vaddr = (unsigned long)
+			pfn_to_kaddr(page_to_xen_pfn(map->pages[i]));
+
+		gnttab_set_unmap_op(&unmap_ops[i], vaddr, GNTMAP_host_map,
+				map->handles[i]);
+	}
+
+	ret = gnttab_unmap_refs(unmap_ops, NULL, map->pages, map->count);
+	if (ret) {
+		kvfree(unmap_ops);
+		return ret;
+	}
+
+	for (i = 0; i < map->count; i++) {
+		if (unmap_ops[i].status != GNTST_okay)
 			ret = -EINVAL;
-		map->unmap_ops[i].handle = -1;
+		map->handles[i] = -1;
+	}
+
+	kvfree(unmap_ops);
+
+	return ret;
+}
+
+static void vhost_xen_foreign_free_map(struct vhost_xen_map *map)
+{
+	if (!map)
+		return;
+
+	if (map->pages)
+		xen_free_unpopulated_pages(map->count, map->pages);
+
+	kvfree(map->pages);
+	kfree(map);
+}
+
+static struct vhost_xen_map *vhost_xen_foreign_alloc_map(int count)
+{
+	struct vhost_xen_map *map;
+
+	map = kzalloc(sizeof(*map), GFP_KERNEL);
+	if (!map)
+		return NULL;
+
+	map->pages = kvcalloc(count, sizeof(map->pages[0]), GFP_KERNEL);
+	if (!map->pages)
+		goto err;
+
+	if (xen_alloc_unpopulated_pages(count, map->pages))
+		goto err;
+
+	map->count = count;
+
+	return map;
+
+err:
+	vhost_xen_foreign_free_map(map);
+
+	return NULL;
+}
+
+static int vhost_xen_foreign_map_pages(struct vhost_xen_map *map, u64 gpaddr,
+		bool readonly)
+{
+	xen_pfn_t *gpfns;
+	xen_ulong_t *idxs;
+	int *errs;
+	int i, ret;
+
+	struct xen_add_to_physmap_range xatp = {
+		.domid = DOMID_SELF,
+		.foreign_domid = map->domid,
+		.space = XENMAPSPACE_gmfn_foreign,
+	};
+
+	gpfns = kvcalloc(map->count, sizeof(xen_pfn_t), GFP_KERNEL);
+	idxs = kvcalloc(map->count, sizeof(xen_ulong_t), GFP_KERNEL);
+	errs = kvcalloc(map->count, sizeof(int), GFP_KERNEL);
+	if (!gpfns || !idxs || !errs) {
+		ret = -ENOMEM;
+		goto out;
+	}
+
+	for (i = 0; i < map->count; i++) {
+		xen_pfn_t pfn = page_to_xen_pfn(map->pages[i / XEN_PFN_PER_PAGE]);
+		xen_ulong_t idx = XEN_PFN_DOWN(gpaddr) + i;
+
+		gpfns[i] = pfn + (i % XEN_PFN_PER_PAGE);
+		idxs[i] = idx;
+		errs[i] = 0;
+	}
+
+	xatp.size = map->count;
+	set_xen_guest_handle(xatp.gpfns, gpfns);
+	set_xen_guest_handle(xatp.idxs, idxs);
+	set_xen_guest_handle(xatp.errs, errs);
+
+	ret = HYPERVISOR_memory_op(XENMEM_add_to_physmap_range, &xatp);
+	for (i = 0; i < map->count; i++) {
+		if (errs[i] && !ret)
+			ret = errs[i];
+	}
+
+out:
+	kvfree(gpfns);
+	kvfree(idxs);
+	kvfree(errs);
+
+	return ret;
+}
+
+static int vhost_xen_foreign_unmap_pages(struct vhost_xen_map *map)
+{
+	int i, ret = 0;
+	struct xen_remove_from_physmap xrp;
+
+	for (i = 0; i < map->count; i++) {
+		xen_pfn_t pfn = page_to_xen_pfn(map->pages[i / XEN_PFN_PER_PAGE]);
+
+		xrp.domid = DOMID_SELF;
+		xrp.gpfn = pfn + (i % XEN_PFN_PER_PAGE);
+
+		ret = HYPERVISOR_memory_op(XENMEM_remove_from_physmap, &xrp);
+		if (ret)
+			return ret;
 	}
 
 	return ret;
 }
 
-static void vhost_xen_put_map(struct vhost_xen_grant_map *map)
+static void vhost_xen_put_map(struct vhost_xen_map *map)
 {
 	if (!map)
 		return;
@@ -140,18 +274,18 @@ static void vhost_xen_put_map(struct vhost_xen_grant_map *map)
 	if (map->pages) {
 		int ret;
 
-		ret = vhost_xen_unmap_pages(map);
+		ret = vhost_xen_ops->unmap_pages(map);
 		if (ret)
 			pr_err("%s: Failed to unmap pages from dom%d (ret=%d)\n",
 					__func__, map->domid, ret);
 	}
-	vhost_xen_free_map(map);
+	vhost_xen_ops->free_map(map);
 }
 
-static struct vhost_xen_grant_map *vhost_xen_find_map(struct vhost_virtqueue *vq,
+static struct vhost_xen_map *vhost_xen_find_map(struct vhost_virtqueue *vq,
 		unsigned long vaddr, int count)
 {
-	struct vhost_xen_grant_map *map;
+	struct vhost_xen_map *map;
 
 	list_for_each_entry(map, &vq->desc_maps, next) {
 		if (map->vaddr != vaddr)
@@ -166,13 +300,13 @@ static struct vhost_xen_grant_map *vhost_xen_find_map(struct vhost_virtqueue *vq
 
 void vhost_xen_unmap_desc_all(struct vhost_virtqueue *vq)
 {
-	struct vhost_xen_grant_map *map;
+	struct vhost_xen_map *map;
 
 	if (!xen_domain())
 		return;
 
 	while (!list_empty(&vq->desc_maps)) {
-		map = list_entry(vq->desc_maps.next, struct vhost_xen_grant_map, next);
+		map = list_entry(vq->desc_maps.next, struct vhost_xen_map, next);
 		list_del(&map->next);
 
 		pr_debug("%s: dom%d: vaddr 0x%lx count %u\n",
@@ -181,39 +315,34 @@ void vhost_xen_unmap_desc_all(struct vhost_virtqueue *vq)
 	}
 }
 
-void *vhost_xen_map_desc(struct vhost_virtqueue *vq, u64 addr, u32 size, int access)
+void *vhost_xen_map_desc(struct vhost_virtqueue *vq, u64 addr, u32 size,
+		int access)
 {
-	struct vhost_xen_grant_map *map;
+	struct vhost_xen_map *map;
 	unsigned long offset = xen_offset_in_page(addr);
 	int count = XEN_PFN_UP(offset + size);
-	int i, ret;
+	int ret;
 
 	if (!xen_domain() || guest_domid == DOMID_INVALID)
 		return ERR_PTR(-ENODEV);
 
-	if (!(addr & XEN_GRANT_DMA_ADDR_OFF)) {
-		pr_err("%s: Descriptor from dom%d cannot be mapped (0x%llx is not a Xen grant address)\n",
-				__func__, guest_domid, addr);
+	if ((nogrant && (addr & XEN_GRANT_DMA_ADDR_OFF)) ||
+			(!nogrant && !(addr & XEN_GRANT_DMA_ADDR_OFF))) {
+		pr_err("%s: Descriptor from dom%d cannot be mapped via Xen %s mappings (addr 0x%llx)\n",
+				__func__, guest_domid, nogrant ? "foreign" : "grant", addr);
 		return ERR_PTR(-EINVAL);
 	}
 
-	map = vhost_xen_alloc_map(count);
+	map = vhost_xen_ops->alloc_map(count);
 	if (!map)
 		return ERR_PTR(-ENOMEM);
 
 	map->domid = guest_domid;
-	for (i = 0; i < count; i++)
-		map->grefs[i] = ((addr & ~XEN_GRANT_DMA_ADDR_OFF) >> XEN_PAGE_SHIFT) + i;
-
-	map->flags |= GNTMAP_host_map;
-	if (access == VHOST_ACCESS_RO)
-		map->flags |= GNTMAP_readonly;
-
-	ret = vhost_xen_map_pages(map);
+	ret = vhost_xen_ops->map_pages(map, addr, access == VHOST_ACCESS_RO);
 	if (ret) {
 		pr_err("%s: Failed to map pages from dom%d (ret=%d)\n",
 				__func__, map->domid, ret);
-		vhost_xen_put_map(map);
+		vhost_xen_ops->free_map(map);
 		return ERR_PTR(ret);
 	}
 
@@ -236,7 +365,7 @@ void *vhost_xen_map_desc(struct vhost_virtqueue *vq, u64 addr, u32 size, int acc
 	list_add_tail(&map->next, &vq->desc_maps);
 
 	pr_debug("%s: dom%d: addr 0x%llx size 0x%x (access 0x%x) -> vaddr 0x%lx count %u (paddr 0x%llx)\n",
-			__func__, map->domid, addr, size, access, map->vaddr, count,
+			__func__, map->domid, addr, size, access, map->vaddr, map->count,
 			page_to_phys(map->pages[0]));
 
 	return (void *)(map->vaddr + offset);
@@ -244,7 +373,7 @@ void *vhost_xen_map_desc(struct vhost_virtqueue *vq, u64 addr, u32 size, int acc
 
 void vhost_xen_unmap_desc(struct vhost_virtqueue *vq, void *ptr, u32 size)
 {
-	struct vhost_xen_grant_map *map;
+	struct vhost_xen_map *map;
 	unsigned long offset = xen_offset_in_page(ptr);
 	int count = XEN_PFN_UP(offset + size);
 
@@ -260,6 +389,20 @@ void vhost_xen_unmap_desc(struct vhost_virtqueue *vq, void *ptr, u32 size)
 		vhost_xen_put_map(map);
 	}
 }
+
+static const struct vhost_xen_ops vhost_xen_grant_ops = {
+	.alloc_map = vhost_xen_grant_alloc_map,
+	.free_map = vhost_xen_grant_free_map,
+	.map_pages = vhost_xen_grant_map_pages,
+	.unmap_pages = vhost_xen_grant_unmap_pages,
+};
+
+static const struct vhost_xen_ops vhost_xen_foreign_ops = {
+	.alloc_map = vhost_xen_foreign_alloc_map,
+	.free_map = vhost_xen_foreign_free_map,
+	.map_pages = vhost_xen_foreign_map_pages,
+	.unmap_pages = vhost_xen_foreign_unmap_pages,
+};
 
 static void vhost_xen_get_guest_domid(struct xenbus_watch *watch,
 		const char *path, const char *token)
@@ -308,7 +451,10 @@ static int __init vhost_xen_init(void)
 
 	register_xenstore_notifier(&vhost_xen_notifier);
 
-	pr_info("%s: Initialize module for Xen grant mappings\n", __func__);
+	vhost_xen_ops = nogrant ? &vhost_xen_foreign_ops : &vhost_xen_grant_ops;
+
+	pr_info("%s: Initialize module for Xen %s mappings\n", __func__,
+			nogrant ? "foreign" : "grant");
 
 	return 0;
 }
@@ -321,6 +467,6 @@ static void __exit vhost_xen_exit(void)
 module_init(vhost_xen_init);
 module_exit(vhost_xen_exit);
 
-MODULE_DESCRIPTION("Xen grant mappings module for vhost");
+MODULE_DESCRIPTION("Xen specific mappings for vhost");
 MODULE_AUTHOR("Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>");
 MODULE_LICENSE("GPL v2");


### PR DESCRIPTION
Patches are added in the same order they appear in https://github.com/xen-troops/meta-xt-vhost/blob/main/recipes-kernel/linux/linux-renesas_%25.bbappend

- vhost_xen: Implement Xen grant mappings module for vhost 
- vhost_xen: Get the guest domid from Xenstore 
- vhost_xen: Implement Xen foreign mappings along with grant mappings 
- vhost_xen: Adapt net for Xen specific mappings 
- vhost_xen: Change a logic to get the guest domid 