### PR TITLE
MFIS & rPROC

### DIFF
--- a/drivers/misc/Kconfig
+++ b/drivers/misc/Kconfig
@@ -523,4 +523,5 @@ source "drivers/misc/habanalabs/Kconfig"
 source "drivers/misc/uacce/Kconfig"
 source "drivers/misc/pvpanic/Kconfig"
 source "drivers/misc/mchp_pci1xxxx/Kconfig"
+source "drivers/misc/rcar-mfis/Kconfig"
 endmenu

--- a/drivers/misc/Makefile
+++ b/drivers/misc/Makefile
@@ -63,3 +63,4 @@ obj-$(CONFIG_OPEN_DICE)		+= open-dice.o
 obj-$(CONFIG_GP_PCI1XXXX)	+= mchp_pci1xxxx/
 obj-$(CONFIG_VCPU_STALL_DETECTOR)	+= vcpu_stall_detector.o
 obj-$(CONFIG_UID_SYS_STATS)	+= uid_sys_stats.o
+obj-$(CONFIG_RCAR_MFIS)		+= rcar-mfis/

--- a/drivers/misc/rcar-mfis/Kconfig
+++ b/drivers/misc/rcar-mfis/Kconfig
@@ -1,0 +1,10 @@
+config RCAR_MFIS
+       tristate "R-Car MFIS driver"
+       depends on OF
+       depends on ARM || ARM64
+       depends on ARCH_RENESAS
+       help
+         MFIS (Multifunctional Interface) allows inter-processor communication
+	 for R-Car Gen5 SoC.
+         To compile this driver as a module, choose M here. The module
+         will be called rcar-mfis.

--- a/drivers/misc/rcar-mfis/Kconfig
+++ b/drivers/misc/rcar-mfis/Kconfig
@@ -2,7 +2,6 @@ config RCAR_MFIS
        tristate "R-Car MFIS driver"
        depends on OF
        depends on ARM || ARM64
-       depends on ARCH_RENESAS
        help
          MFIS (Multifunctional Interface) allows inter-processor communication
 	 for R-Car Gen5 SoC.

--- a/drivers/misc/rcar-mfis/Makefile
+++ b/drivers/misc/rcar-mfis/Makefile
@@ -1,0 +1,3 @@
+rcar-mfis-y := rcar_mfis_drv.o
+
+obj-$(CONFIG_RCAR_MFIS) += rcar-mfis.o

--- a/drivers/misc/rcar-mfis/rcar_mfis_drv.c
+++ b/drivers/misc/rcar-mfis/rcar_mfis_drv.c
@@ -136,12 +136,13 @@ static int rcar_mfis_probe(struct platform_device *pdev)
 	u32 value;
 	int ret, i;
 
-	num_mfis_channels = of_property_count_elems_of_size(dev->of_node, "renesas,mfis-channels",
+	ret = of_property_count_elems_of_size(dev->of_node, "renesas,mfis-channels",
 							    sizeof(u32));
-	if (value == -EINVAL) {
+	if (ret < 0 ) {
 		dev_err(dev, "can't find renesas,mfis-channels property\n");
-		return value;
+		return ret;
 	}
+	num_mfis_channels = ret;
 
 	/* Allocate device struct */
 	rcmfis_priv = kzalloc(sizeof(*rcmfis_priv), GFP_KERNEL);
@@ -152,15 +153,13 @@ static int rcar_mfis_probe(struct platform_device *pdev)
 
 	res = platform_get_resource_byname(pdev, IORESOURCE_MEM, "unlock_reg");
 	if (!res) {
-		dev_err(dev, "Failed to get write protection registger.\n");
-		ret = -EINVAL;
-		goto free_mfis_dev;
+		dev_warn(dev, "no write protection register in device node, skipping.\n");
+	} else {
+		/* Unlock register write protection */
+		unlock = ioremap(res->start, 4);
+		iowrite32(0xACC00001, unlock);
+		iounmap(unlock);
 	}
-
-	/* Unlock register write protection */
-	unlock = ioremap(res->start, 4);
-	iowrite32(0xACC00001, unlock);
-	iounmap(unlock);
 
 	for (i = 0; i < num_mfis_channels; i++) {
 		struct rcar_mfis_ch *mfis_ch;
@@ -173,7 +172,7 @@ static int rcar_mfis_probe(struct platform_device *pdev)
 		else if (value < 0 || value >= NUM_MFIS_CHANNELS)
 			continue;
 
-		mfis_ch = &rcmfis_priv->channels[value];
+		mfis_ch = &rcmfis_priv->channels[i];
 		if (mfis_ch->initialized) {
 			dev_warn(dev, "mfis channel %d is already initialized. Skipping.\n", value);
 			continue;
@@ -204,8 +203,8 @@ static int rcar_mfis_probe(struct platform_device *pdev)
 			continue;
 		}
 
-		/* Get IRQ resource */
-		irq = platform_get_irq(pdev, mfis_ch->id);
+		/* Get IRQ resource by "ch#<id>" name from DT */
+		irq = platform_get_irq_byname(pdev, pdev_chname);
 		if (!irq) {
 			dev_err(dev, "missing IRQ for channel %d. Skipping.\n", mfis_ch->id);
 			continue;
@@ -231,10 +230,6 @@ static int rcar_mfis_probe(struct platform_device *pdev)
 	}
 
 	return 0;
-
-free_mfis_dev:
-	kfree(rcmfis_priv);
-	return ret;
 }
 
 static int rcar_mfis_remove(struct platform_device *pdev)

--- a/drivers/misc/rcar-mfis/rcar_mfis_drv.c
+++ b/drivers/misc/rcar-mfis/rcar_mfis_drv.c
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: GPL-2.0
+/* R-Car MFIS driver
+ *
+ * Copyright (C) 2025 Renesas Electronics Corporation
+ */
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/of_device.h>
+#include <linux/of_address.h>
+#include <linux/platform_device.h>
+#include <linux/io.h>
+#include <linux/interrupt.h>
+#include <linux/slab.h>
+#include <linux/notifier.h>
+
+#include "rcar_mfis_drv.h"
+#include <misc/rcar-mfis/rcar_mfis_public.h>
+
+#define IICR(n) (0x0000 + (n) * 0x1000)
+#define EICR(n) (0x0004 + (n) * 0x1000)
+#define IMBR(n) (0x0040 + (n) * 0x1000)
+#define EMBR(n) (0x0044 + (n) * 0x1000)
+
+static struct rcar_mfis_priv *rcmfis_priv;
+
+static irqreturn_t mfis_irq_handler(int irq, void *data)
+{
+	u32 value = 0;
+	struct rcar_mfis_msg msg;
+	struct rcar_mfis_ch *rcar_mfis_ch = (struct rcar_mfis_ch *)data;
+	unsigned int ch = rcar_mfis_ch->id;
+
+	value = rcar_mfis_reg_read(rcmfis_priv, IICR(ch));
+	if (value & 0x1) {
+		msg.mbr = rcar_mfis_reg_read(rcmfis_priv, IMBR(ch));
+		msg.icr = value >> 1;
+
+		atomic_notifier_call_chain(&rcar_mfis_ch->notifier_head, msg.icr,
+					   rcar_mfis_ch->notifier_data);
+
+		/* clear interrupt flag */
+		rcar_mfis_reg_write(rcmfis_priv, IICR(ch), value & (~0x1));
+
+		return IRQ_HANDLED;
+	}
+
+	return IRQ_NONE;
+}
+
+static struct rcar_mfis_ch *rcar_mfis_channel_get(unsigned int channel)
+{
+	struct rcar_mfis_ch *rcar_mfis_ch;
+	int i;
+
+	for (i = 0; i < NUM_MFIS_CHANNELS; i++) {
+		if (rcmfis_priv->channels[i].initialized &&
+		    rcmfis_priv->channels[i].id == channel) {
+			rcar_mfis_ch = &rcmfis_priv->channels[i];
+			break;
+		}
+	}
+
+	return rcar_mfis_ch;
+}
+
+/****** Exported functions ******/
+
+int rcar_mfis_trigger_interrupt(int channel, struct rcar_mfis_msg msg)
+{
+	struct rcar_mfis_ch *rcar_mfis_ch;
+	int ret;
+	u32 icr;
+
+	rcar_mfis_ch = rcar_mfis_channel_get(channel);
+	if (!rcar_mfis_ch)
+		return -EINVAL;
+
+	/* Check whether the remote proccessor is still processing a previous interrupt */
+	icr = rcar_mfis_reg_read(rcmfis_priv, EICR(channel));
+	if (icr & 0x1)
+		return -EBUSY;
+
+	rcar_mfis_reg_write(rcmfis_priv, EMBR(channel), msg.mbr);
+	rcar_mfis_reg_write(rcmfis_priv, EICR(channel), (msg.icr << 1) | 1);
+
+	return ret;
+}
+EXPORT_SYMBOL(rcar_mfis_trigger_interrupt);
+
+int rcar_mfis_register_notifier(int channel, struct notifier_block *nb, void *data)
+{
+	struct rcar_mfis_ch *rcar_mfis_ch;
+	struct atomic_notifier_head *nh;
+
+	rcar_mfis_ch = rcar_mfis_channel_get(channel);
+	if (!rcar_mfis_ch)
+		return -EINVAL;
+
+	if (!rcmfis_priv)
+		return -ENXIO;
+
+	rcar_mfis_ch->notifier_data = data;
+
+	nh = &rcar_mfis_ch->notifier_head;
+	return atomic_notifier_chain_register(nh, nb);
+}
+EXPORT_SYMBOL(rcar_mfis_register_notifier);
+
+int rcar_mfis_unregister_notifier(int channel, struct notifier_block *nb)
+{
+	struct rcar_mfis_ch *rcar_mfis_ch;
+	struct atomic_notifier_head *nh;
+
+	rcar_mfis_ch = rcar_mfis_channel_get(channel);
+	if (!rcar_mfis_ch)
+		return -EINVAL;
+
+	if (!rcmfis_priv)
+		return -ENXIO;
+
+	nh = &rcar_mfis_ch->notifier_head;
+	return atomic_notifier_chain_unregister(nh, nb);
+}
+EXPORT_SYMBOL(rcar_mfis_unregister_notifier);
+
+static int rcar_mfis_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	u32 __iomem *mmio_base, *unlock;
+	struct resource *res;
+	u32 num_mfis_channels;
+	u32 value;
+	int ret, i;
+	int irq;
+
+	num_mfis_channels = of_property_count_elems_of_size(dev->of_node, "renesas,mfis-channels",
+							    sizeof(u32));
+	if (value == -EINVAL) {
+		dev_err(dev, "can't find renesas,mfis-channels property\n");
+		return value;
+	}
+
+	/* Allocate device struct */
+	rcmfis_priv = kzalloc(sizeof(*rcmfis_priv), GFP_KERNEL);
+	if (!rcmfis_priv)
+		return -ENOMEM;
+
+	rcmfis_priv->pdev = pdev;
+
+	/* Map MFIS registers */
+	res = platform_get_resource_byname(pdev, IORESOURCE_MEM, "io_base");
+	if (!res) {
+		dev_err(dev, "Failed to get MFIS IO base.\n");
+		ret = -EINVAL;
+		goto free_mfis_dev;
+	}
+
+	mmio_base = (u32 __iomem *)devm_ioremap(dev, res->start, resource_size(res));
+	if (IS_ERR(mmio_base)) {
+		dev_err(dev, "Failed to remap MFIS registers.\n");
+		ret = PTR_ERR(mmio_base);
+		goto free_mfis_dev;
+	}
+
+	res = platform_get_resource_byname(pdev, IORESOURCE_MEM, "unlock_reg");
+	if (!res) {
+		dev_err(dev, "Failed to get write protection registger.\n");
+		ret = -EINVAL;
+		goto free_mfis_dev;
+	}
+
+	/* Unlock register write protection */
+	unlock = ioremap(res->start, 4);
+	iowrite32(0xACC00001, unlock);
+	iounmap(unlock);
+
+	rcmfis_priv->mmio_base = mmio_base;
+
+	for (i = 0; i < num_mfis_channels; i++) {
+		struct rcar_mfis_ch *mfis_ch;
+
+		ret = of_property_read_u32_index(dev->of_node, "renesas,mfis-channels", i, &value);
+		if (ret)
+			continue;
+		else if (value < 0 || value >= NUM_MFIS_CHANNELS)
+			continue;
+
+		mfis_ch = &rcmfis_priv->channels[value];
+		if (mfis_ch->initialized) {
+			dev_warn(dev, "mfis channel %d is already initialized. Skipping.\n", value);
+			continue;
+		}
+
+		mfis_ch->id = value;
+
+		ATOMIC_INIT_NOTIFIER_HEAD(&mfis_ch->notifier_head);
+
+		/* Get IRQ resource */
+		irq = platform_get_irq(pdev, mfis_ch->id);
+		if (!irq) {
+			dev_err(dev, "missing IRQ for channel %d. Skipping.\n", mfis_ch->id);
+			continue;
+		}
+
+		ret = devm_request_irq(dev, irq, mfis_irq_handler, IRQF_SHARED,
+				       dev_name(dev), mfis_ch);
+		if (ret < 0) {
+			dev_err(dev, "failed to request IRQ for channel %d. Skipping.\n",
+				mfis_ch->id);
+			continue;
+		}
+
+		mfis_ch->initialized = 1;
+		dev_info(dev, "channel %d initialized\n", mfis_ch->id);
+	}
+
+	return 0;
+
+free_mfis_dev:
+	kfree(rcmfis_priv);
+	return ret;
+}
+
+static int rcar_mfis_remove(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+
+	dev_info(dev, "R-Car MFIS remove\n");
+	kfree(rcmfis_priv);
+
+	return 0;
+}
+
+static const struct of_device_id rcar_mfis_of_match[] = {
+	{ .compatible = "renesas,mfis" },
+	{ },
+};
+MODULE_DEVICE_TABLE(of, rcar_mfis_of_match);
+
+static struct platform_driver rcar_mfis_driver = {
+	.probe      = rcar_mfis_probe,
+	.remove     = rcar_mfis_remove,
+	.driver     = {
+		.name   = "rcar_mfis",
+		.of_match_table = rcar_mfis_of_match,
+	},
+};
+
+static int __init rcar_mfis_init(void)
+{
+	return platform_driver_register(&rcar_mfis_driver);
+}
+core_initcall(rcar_mfis_init);
+
+static void __exit rcar_mfis_exit(void)
+{
+	platform_driver_unregister(&rcar_mfis_driver);
+}
+module_exit(rcar_mfis_exit);
+
+MODULE_LICENSE("GPL");

--- a/drivers/misc/rcar-mfis/rcar_mfis_drv.c
+++ b/drivers/misc/rcar-mfis/rcar_mfis_drv.c
@@ -18,10 +18,10 @@
 #include "rcar_mfis_drv.h"
 #include <misc/rcar-mfis/rcar_mfis_public.h>
 
-#define IICR(n) (0x0000 + (n) * 0x1000)
-#define EICR(n) (0x0004 + (n) * 0x1000)
-#define IMBR(n) (0x0040 + (n) * 0x1000)
-#define EMBR(n) (0x0044 + (n) * 0x1000)
+#define IICR	(0x0000)
+#define EICR	(0x0004)
+#define IMBR	(0x0040)
+#define EMBR	(0x0044)
 
 static struct rcar_mfis_priv *rcmfis_priv;
 
@@ -30,18 +30,17 @@ static irqreturn_t mfis_irq_handler(int irq, void *data)
 	u32 value = 0;
 	struct rcar_mfis_msg msg;
 	struct rcar_mfis_ch *rcar_mfis_ch = (struct rcar_mfis_ch *)data;
-	unsigned int ch = rcar_mfis_ch->id;
 
-	value = rcar_mfis_reg_read(rcmfis_priv, IICR(ch));
+	value = rcar_mfis_reg_read(rcar_mfis_ch, IICR);
 	if (value & 0x1) {
-		msg.mbr = rcar_mfis_reg_read(rcmfis_priv, IMBR(ch));
+		msg.mbr = rcar_mfis_reg_read(rcar_mfis_ch, IMBR);
 		msg.icr = value >> 1;
 
 		atomic_notifier_call_chain(&rcar_mfis_ch->notifier_head, msg.icr,
 					   rcar_mfis_ch->notifier_data);
 
 		/* clear interrupt flag */
-		rcar_mfis_reg_write(rcmfis_priv, IICR(ch), value & (~0x1));
+		rcar_mfis_reg_write(rcar_mfis_ch, IICR, value & (~0x1));
 
 		return IRQ_HANDLED;
 	}
@@ -53,6 +52,9 @@ static struct rcar_mfis_ch *rcar_mfis_channel_get(unsigned int channel)
 {
 	struct rcar_mfis_ch *rcar_mfis_ch;
 	int i;
+
+	if (!rcmfis_priv)
+		return NULL;
 
 	for (i = 0; i < NUM_MFIS_CHANNELS; i++) {
 		if (rcmfis_priv->channels[i].initialized &&
@@ -78,12 +80,12 @@ int rcar_mfis_trigger_interrupt(int channel, struct rcar_mfis_msg msg)
 		return -EINVAL;
 
 	/* Check whether the remote proccessor is still processing a previous interrupt */
-	icr = rcar_mfis_reg_read(rcmfis_priv, EICR(channel));
+	icr = rcar_mfis_reg_read(rcar_mfis_ch, EICR);
 	if (icr & 0x1)
 		return -EBUSY;
 
-	rcar_mfis_reg_write(rcmfis_priv, EMBR(channel), msg.mbr);
-	rcar_mfis_reg_write(rcmfis_priv, EICR(channel), (msg.icr << 1) | 1);
+	rcar_mfis_reg_write(rcar_mfis_ch, EMBR, msg.mbr);
+	rcar_mfis_reg_write(rcar_mfis_ch, EICR, (msg.icr << 1) | 1);
 
 	return ret;
 }
@@ -128,12 +130,11 @@ EXPORT_SYMBOL(rcar_mfis_unregister_notifier);
 static int rcar_mfis_probe(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
-	u32 __iomem *mmio_base, *unlock;
+	u32 __iomem *unlock;
 	struct resource *res;
 	u32 num_mfis_channels;
 	u32 value;
 	int ret, i;
-	int irq;
 
 	num_mfis_channels = of_property_count_elems_of_size(dev->of_node, "renesas,mfis-channels",
 							    sizeof(u32));
@@ -149,21 +150,6 @@ static int rcar_mfis_probe(struct platform_device *pdev)
 
 	rcmfis_priv->pdev = pdev;
 
-	/* Map MFIS registers */
-	res = platform_get_resource_byname(pdev, IORESOURCE_MEM, "io_base");
-	if (!res) {
-		dev_err(dev, "Failed to get MFIS IO base.\n");
-		ret = -EINVAL;
-		goto free_mfis_dev;
-	}
-
-	mmio_base = (u32 __iomem *)devm_ioremap(dev, res->start, resource_size(res));
-	if (IS_ERR(mmio_base)) {
-		dev_err(dev, "Failed to remap MFIS registers.\n");
-		ret = PTR_ERR(mmio_base);
-		goto free_mfis_dev;
-	}
-
 	res = platform_get_resource_byname(pdev, IORESOURCE_MEM, "unlock_reg");
 	if (!res) {
 		dev_err(dev, "Failed to get write protection registger.\n");
@@ -176,10 +162,10 @@ static int rcar_mfis_probe(struct platform_device *pdev)
 	iowrite32(0xACC00001, unlock);
 	iounmap(unlock);
 
-	rcmfis_priv->mmio_base = mmio_base;
-
 	for (i = 0; i < num_mfis_channels; i++) {
 		struct rcar_mfis_ch *mfis_ch;
+		char *pdev_chname, *pdev_irqname;
+		int irq;
 
 		ret = of_property_read_u32_index(dev->of_node, "renesas,mfis-channels", i, &value);
 		if (ret)
@@ -197,6 +183,27 @@ static int rcar_mfis_probe(struct platform_device *pdev)
 
 		ATOMIC_INIT_NOTIFIER_HEAD(&mfis_ch->notifier_head);
 
+		pdev_chname = kasprintf(GFP_KERNEL, "ch%u", mfis_ch->id);
+		if (!pdev_chname) {
+			dev_err(dev, "failed to create channel %d name. Skipping.\n", mfis_ch->id);
+			continue;
+		}
+
+		/* Get channel base address */
+		res = platform_get_resource_byname(pdev, IORESOURCE_MEM, pdev_chname);
+		if (!res) {
+			dev_err(dev, "missing base address for channel %d. Skipping.\n",
+				mfis_ch->id);
+			continue;
+		}
+
+		mfis_ch->base = devm_ioremap_resource(dev, res);
+		if (!mfis_ch->base) {
+			dev_err(dev, "failed to map IO memory for channel %d\n. Skipping.\n",
+				mfis_ch->id);
+			continue;
+		}
+
 		/* Get IRQ resource */
 		irq = platform_get_irq(pdev, mfis_ch->id);
 		if (!irq) {
@@ -204,8 +211,15 @@ static int rcar_mfis_probe(struct platform_device *pdev)
 			continue;
 		}
 
+		pdev_irqname = devm_kasprintf(dev, GFP_KERNEL, "mfis_ch%u", mfis_ch->id);
+		if (!pdev_irqname) {
+			dev_err(dev, "failed to create irqname of channel %d name. Skipping.\n",
+				mfis_ch->id);
+			continue;
+		}
+
 		ret = devm_request_irq(dev, irq, mfis_irq_handler, IRQF_SHARED,
-				       dev_name(dev), mfis_ch);
+				       pdev_irqname, mfis_ch);
 		if (ret < 0) {
 			dev_err(dev, "failed to request IRQ for channel %d. Skipping.\n",
 				mfis_ch->id);

--- a/drivers/misc/rcar-mfis/rcar_mfis_drv.h
+++ b/drivers/misc/rcar-mfis/rcar_mfis_drv.h
@@ -10,6 +10,7 @@
 struct rcar_mfis_ch {
 	unsigned int id;
 	int initialized;
+	void __iomem *base;
 	struct atomic_notifier_head notifier_head;
 	void *notifier_data;
 };
@@ -18,18 +19,17 @@ struct rcar_mfis_ch {
 
 struct rcar_mfis_priv {
 	struct platform_device *pdev;
-	void __iomem *mmio_base;
 	struct rcar_mfis_ch channels[NUM_MFIS_CHANNELS];
 };
 
-static inline u32 rcar_mfis_reg_read(struct rcar_mfis_priv *mfis_priv, u32 reg)
+static inline u32 rcar_mfis_reg_read(struct rcar_mfis_ch *chan, u32 reg)
 {
-	return ioread32(mfis_priv->mmio_base + reg);
+	return ioread32(chan->base + reg);
 }
 
-static inline void rcar_mfis_reg_write(struct rcar_mfis_priv *mfis_priv, u32 reg, u32 data)
+static inline void rcar_mfis_reg_write(struct rcar_mfis_ch *chan, u32 reg, u32 data)
 {
-	iowrite32(data, mfis_priv->mmio_base + reg);
+	iowrite32(data, chan->base + reg);
 }
 
 #endif

--- a/drivers/misc/rcar-mfis/rcar_mfis_drv.h
+++ b/drivers/misc/rcar-mfis/rcar_mfis_drv.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#ifndef _RCAR_MFIS_H_
+#define _RCAR_MFIS_H_
+
+#include <linux/platform_device.h>
+#include <linux/io.h>
+#include <linux/notifier.h>
+
+struct rcar_mfis_ch {
+	unsigned int id;
+	int initialized;
+	struct atomic_notifier_head notifier_head;
+	void *notifier_data;
+};
+
+#define NUM_MFIS_CHANNELS       64
+
+struct rcar_mfis_priv {
+	struct platform_device *pdev;
+	void __iomem *mmio_base;
+	struct rcar_mfis_ch channels[NUM_MFIS_CHANNELS];
+};
+
+static inline u32 rcar_mfis_reg_read(struct rcar_mfis_priv *mfis_priv, u32 reg)
+{
+	return ioread32(mfis_priv->mmio_base + reg);
+}
+
+static inline void rcar_mfis_reg_write(struct rcar_mfis_priv *mfis_priv, u32 reg, u32 data)
+{
+	iowrite32(data, mfis_priv->mmio_base + reg);
+}
+
+#endif

--- a/drivers/remoteproc/Kconfig
+++ b/drivers/remoteproc/Kconfig
@@ -298,6 +298,15 @@ config RCAR_REMOTEPROC
 	  This can be either built-in or a loadable module.
 	  If compiled as module (M), the module name is rcar_rproc.
 
+config RCAR_GEN5_REMOTEPROC
+	tristate "Renesas R-Car Gen5 remoteproc support"
+	depends on ARCH_RENESAS || COMPILE_TEST
+	help
+	  Say y here to support R-Car Gen5 realtime processor via the
+	  remote processor framework.
+	  This can be either built-in or a loadable module.
+	  If compiled as module (M), the module name is rcar_gen5_rproc.
+
 config ST_REMOTEPROC
 	tristate "ST remoteproc support"
 	depends on ARCH_STI

--- a/drivers/remoteproc/Kconfig
+++ b/drivers/remoteproc/Kconfig
@@ -300,7 +300,6 @@ config RCAR_REMOTEPROC
 
 config RCAR_GEN5_REMOTEPROC
 	tristate "Renesas R-Car Gen5 remoteproc support"
-	depends on ARCH_RENESAS || COMPILE_TEST
 	help
 	  Say y here to support R-Car Gen5 realtime processor via the
 	  remote processor framework.

--- a/drivers/remoteproc/Makefile
+++ b/drivers/remoteproc/Makefile
@@ -33,6 +33,7 @@ obj-$(CONFIG_QCOM_WCNSS_PIL)		+= qcom_wcnss_pil.o
 qcom_wcnss_pil-y			+= qcom_wcnss.o
 qcom_wcnss_pil-y			+= qcom_wcnss_iris.o
 obj-$(CONFIG_RCAR_REMOTEPROC)		+= rcar_rproc.o
+obj-$(CONFIG_RCAR_GEN5_REMOTEPROC)	+= rcar_gen5_rproc.o
 obj-$(CONFIG_ST_REMOTEPROC)		+= st_remoteproc.o
 obj-$(CONFIG_ST_SLIM_REMOTEPROC)	+= st_slim_rproc.o
 obj-$(CONFIG_STM32_RPROC)		+= stm32_rproc.o

--- a/drivers/remoteproc/rcar_gen5_rproc.c
+++ b/drivers/remoteproc/rcar_gen5_rproc.c
@@ -76,6 +76,7 @@ static int rcar_gen5_rproc_prepare(struct rproc *rproc)
 	struct rproc_mem_entry *mem;
 	struct reserved_mem *rmem;
 	u32 da;
+	int index = 0;
 
 	/* Register associated reserved memory regions */
 	of_phandle_iterator_init(&it, np, "memory-region", NULL, 0);
@@ -93,20 +94,28 @@ static int rcar_gen5_rproc_prepare(struct rproc *rproc)
 			return -EINVAL;
 		}
 
-		/* No need to translate pa to da, R-Car use same map */
-		da = rmem->base;
-		mem = rproc_mem_entry_init(dev, NULL,
-					   rmem->base,
-					   rmem->size, da,
-					   rcar_gen5_rproc_mem_alloc,
-					   rcar_gen5_rproc_mem_release,
-					   it.node->name);
+		if (!strncmp(it.node->name, "vdev", sizeof("vdev"))) {
+			mem = rproc_of_resm_mem_entry_init(dev, index,
+							   rmem->size,
+							   rmem->base,
+							   it.node->name);
+		} else {
+			/* No need to translate pa to da, R-Car use same map */
+			da = rmem->base;
+			mem = rproc_mem_entry_init(dev, NULL,
+						   rmem->base,
+						   rmem->size, da,
+						   rcar_gen5_rproc_mem_alloc,
+						   rcar_gen5_rproc_mem_release,
+						   it.node->name);
+		}
 
 		if (!mem) {
 			of_node_put(it.node);
 			return -ENOMEM;
 		}
 
+		index++;
 		rproc_add_carveout(rproc, mem);
 	}
 
@@ -156,7 +165,7 @@ static void rcar_gen5_rproc_kick(struct rproc *rproc, int vqid)
 	} while (ret && n_tries--);
 
 	if (ret)
-		dev_info(dev, "%s failed\n", __func__);
+		dev_dbg(dev, "%s failed\n", __func__);
 }
 
 static int rcar_gen5_rproc_elf_load_segments(struct rproc *rproc, const struct firmware *fw)

--- a/drivers/remoteproc/rcar_gen5_rproc.c
+++ b/drivers/remoteproc/rcar_gen5_rproc.c
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2025 Renesas Electronics Corporation
+ */
+
+#include <linux/limits.h>
+#include <linux/module.h>
+#include <linux/of_device.h>
+#include <linux/of_reserved_mem.h>
+#include <linux/remoteproc.h>
+#include <linux/delay.h>
+
+#include "remoteproc_internal.h"
+#include <misc/rcar-mfis/rcar_mfis_public.h>
+
+struct rcar_rproc {
+	struct rproc *rproc;
+	struct work_struct workqueue;
+	u32 mfis_chan;
+};
+
+static int rcar_gen5_rproc_mem_alloc(struct rproc *rproc, struct rproc_mem_entry *mem)
+{
+	struct device *dev = &rproc->dev;
+	void *va;
+
+	dev_dbg(dev, "map memory: %pa+%zx\n", &mem->dma, mem->len);
+	va = ioremap_wc(mem->dma, mem->len);
+	if (!va) {
+		dev_err(dev, "Unable to map memory region: %pa+%zx\n",
+			&mem->dma, mem->len);
+		return -ENOMEM;
+	}
+
+	/* Update memory entry va */
+	mem->va = va;
+
+	return 0;
+}
+
+static int rcar_gen5_rproc_mem_release(struct rproc *rproc, struct rproc_mem_entry *mem)
+{
+	dev_dbg(&rproc->dev, "unmap memory: %pa\n", &mem->dma);
+	iounmap(mem->va);
+
+	return 0;
+}
+
+static void handle_event(struct work_struct *work)
+{
+	struct rcar_rproc *priv = container_of(work, struct rcar_rproc, workqueue);
+
+	rproc_vq_interrupt(priv->rproc, 0);
+	rproc_vq_interrupt(priv->rproc, 1);
+}
+
+static int rcar_gen5_rproc_interrupt_cb(struct notifier_block *self, unsigned long action,
+					void *data)
+{
+	struct rcar_rproc *priv = (struct rcar_rproc *)data;
+
+	schedule_work(&priv->workqueue);
+
+	return NOTIFY_DONE;
+}
+
+static struct notifier_block rcar_gen5_rproc_notifier_block = {
+	.notifier_call = rcar_gen5_rproc_interrupt_cb,
+};
+
+static int rcar_gen5_rproc_prepare(struct rproc *rproc)
+{
+	struct device *dev = rproc->dev.parent;
+	struct device_node *np = dev->of_node;
+	struct of_phandle_iterator it;
+	struct rproc_mem_entry *mem;
+	struct reserved_mem *rmem;
+	u32 da;
+
+	/* Register associated reserved memory regions */
+	of_phandle_iterator_init(&it, np, "memory-region", NULL, 0);
+	while (of_phandle_iterator_next(&it) == 0) {
+		rmem = of_reserved_mem_lookup(it.node);
+		if (!rmem) {
+			of_node_put(it.node);
+			dev_err(&rproc->dev,
+				"unable to acquire memory-region\n");
+			return -EINVAL;
+		}
+
+		if (rmem->base > U32_MAX) {
+			of_node_put(it.node);
+			return -EINVAL;
+		}
+
+		/* No need to translate pa to da, R-Car use same map */
+		da = rmem->base;
+		mem = rproc_mem_entry_init(dev, NULL,
+					   rmem->base,
+					   rmem->size, da,
+					   rcar_gen5_rproc_mem_alloc,
+					   rcar_gen5_rproc_mem_release,
+					   it.node->name);
+
+		if (!mem) {
+			of_node_put(it.node);
+			return -ENOMEM;
+		}
+
+		rproc_add_carveout(rproc, mem);
+	}
+
+	return 0;
+}
+
+static int rcar_gen5_rproc_parse_fw(struct rproc *rproc, const struct firmware *fw)
+{
+	int ret;
+
+	ret = rproc_elf_load_rsc_table(rproc, fw);
+	if (ret)
+		dev_info(&rproc->dev, "No resource table in elf\n");
+
+	return 0;
+}
+
+static int rcar_gen5_rproc_start(struct rproc *rproc)
+{
+	if (!rproc->bootaddr)
+		return -EINVAL;
+
+	return 0;
+}
+
+static int rcar_gen5_rproc_stop(struct rproc *rproc)
+{
+	return 0;
+}
+
+static void rcar_gen5_rproc_kick(struct rproc *rproc, int vqid)
+{
+	struct device *dev = rproc->dev.parent;
+	struct rcar_rproc *priv = rproc->priv;
+	struct rcar_mfis_msg msg;
+	unsigned int n_tries = 3;
+	int ret;
+
+	msg.icr = vqid;
+	msg.mbr = 0;
+
+	do {
+		ret = rcar_mfis_trigger_interrupt(priv->mfis_chan, msg);
+		if (ret)
+			usleep_range(500, 510);
+
+	} while (ret && n_tries--);
+
+	if (ret)
+		dev_info(dev, "%s failed\n", __func__);
+}
+
+static int rcar_gen5_rproc_elf_load_segments(struct rproc *rproc, const struct firmware *fw)
+{
+	return 0;
+}
+
+static struct rproc_ops rcar_rproc_ops = {
+	.prepare		= rcar_gen5_rproc_prepare,
+	.start			= rcar_gen5_rproc_start,
+	.stop			= rcar_gen5_rproc_stop,
+	.kick			= rcar_gen5_rproc_kick,
+	.load			= rcar_gen5_rproc_elf_load_segments,
+	.parse_fw		= rcar_gen5_rproc_parse_fw,
+	.find_loaded_rsc_table	= rproc_elf_find_loaded_rsc_table,
+	.sanity_check		= rproc_elf_sanity_check,
+	.get_boot_addr		= rproc_elf_get_boot_addr,
+
+};
+
+static int rcar_gen5_rproc_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	struct device_node *np = dev->of_node;
+	struct rcar_rproc *priv;
+	struct rproc *rproc;
+	int ret;
+
+	rproc = devm_rproc_alloc(dev, np->name, &rcar_rproc_ops, NULL, sizeof(*priv));
+	if (!rproc)
+		return -ENOMEM;
+
+	priv = rproc->priv;
+
+	dev_set_drvdata(dev, rproc);
+
+	priv->rproc = rproc;
+
+	INIT_WORK(&priv->workqueue, handle_event);
+
+	ret = of_property_read_u32(np, "renesas,mfis-channel", &priv->mfis_chan);
+	if (!ret) {
+		/* Default is channel 0 */
+		priv->mfis_chan = 0;
+	}
+
+	ret = rcar_mfis_register_notifier(priv->mfis_chan, &rcar_gen5_rproc_notifier_block, priv);
+	if (ret) {
+		dev_err(dev, "cannot register notifier on mfis channel %d\n", 0);
+		return ret;
+	}
+
+	/* Manually start the rproc */
+	rproc->auto_boot = false;
+
+	ret = devm_rproc_add(dev, rproc);
+	if (ret) {
+		dev_err(dev, "rproc_add failed\n");
+		goto unregister_notifier;
+	}
+
+	return 0;
+
+unregister_notifier:
+	rcar_mfis_unregister_notifier(priv->mfis_chan, &rcar_gen5_rproc_notifier_block);
+	flush_work(&priv->workqueue);
+
+	return ret;
+}
+
+static int rcar_gen5_rproc_remove(struct platform_device *pdev)
+{
+	struct rcar_rproc *priv =  platform_get_drvdata(pdev);
+
+	rcar_mfis_unregister_notifier(priv->mfis_chan, &rcar_gen5_rproc_notifier_block);
+	flush_work(&priv->workqueue);
+	rproc_del(priv->rproc);
+
+	return 0;
+}
+
+static const struct of_device_id rcar_gen5_rproc_of_match[] = {
+	{ .compatible = "renesas,r8a78000-rproc" },
+	{ .compatible = "renesas,rcar-gen5-rproc" },
+	{},
+};
+
+MODULE_DEVICE_TABLE(of, rcar_gen5_rproc_of_match);
+
+static struct platform_driver rcar_gen5_rproc_driver = {
+	.probe = rcar_gen5_rproc_probe,
+	.remove = rcar_gen5_rproc_remove,
+	.driver = {
+		.name = "rcar-gen5-rproc",
+		.of_match_table = rcar_gen5_rproc_of_match,
+	},
+};
+
+module_platform_driver(rcar_gen5_rproc_driver);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("Renesas R-Car Gen5 remote processor control driver");
+MODULE_AUTHOR("Phong Hoang <phong.hoang.wz@renesas.com>");

--- a/drivers/remoteproc/rcar_gen5_rproc.c
+++ b/drivers/remoteproc/rcar_gen5_rproc.c
@@ -198,7 +198,7 @@ static int rcar_gen5_rproc_probe(struct platform_device *pdev)
 	INIT_WORK(&priv->workqueue, handle_event);
 
 	ret = of_property_read_u32(np, "renesas,mfis-channel", &priv->mfis_chan);
-	if (!ret) {
+	if (ret) {
 		/* Default is channel 0 */
 		priv->mfis_chan = 0;
 	}

--- a/drivers/remoteproc/rcar_gen5_rproc.c
+++ b/drivers/remoteproc/rcar_gen5_rproc.c
@@ -205,7 +205,7 @@ static int rcar_gen5_rproc_probe(struct platform_device *pdev)
 
 	ret = rcar_mfis_register_notifier(priv->mfis_chan, &rcar_gen5_rproc_notifier_block, priv);
 	if (ret) {
-		dev_err(dev, "cannot register notifier on mfis channel %d\n", 0);
+		dev_err(dev, "cannot register notifier on mfis channel %d\n", priv->mfis_chan);
 		return ret;
 	}
 

--- a/drivers/remoteproc/remoteproc_virtio.c
+++ b/drivers/remoteproc/remoteproc_virtio.c
@@ -523,6 +523,7 @@ static int rproc_virtio_probe(struct platform_device *pdev)
 		dev_warn(dev, "Failed to set DMA mask %llx. Trying to continue... (%pe)\n",
 			 dma_get_mask(rproc->dev.parent), ERR_PTR(ret));
 	}
+	dev->dma_coherent = rproc->dev.parent->dma_coherent;
 
 	platform_set_drvdata(pdev, rvdev);
 	rvdev->pdev = pdev;

--- a/include/misc/rcar-mfis/rcar_mfis_public.h
+++ b/include/misc/rcar-mfis/rcar_mfis_public.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#ifndef __RCAR_MFIS_PUBLIC_H__
+#define __RCAR_MFIS_PUBLIC_H__
+
+struct rcar_mfis_msg {
+	u32 icr;
+	u32 mbr;
+};
+
+int rcar_mfis_trigger_interrupt(int channel, struct rcar_mfis_msg msg);
+int rcar_mfis_register_notifier(int channel, struct notifier_block *nb, void *data);
+int rcar_mfis_unregister_notifier(int channel, struct notifier_block *nb);
+
+#endif


### PR DESCRIPTION
The patches in PR are rebased from Linux BSP for Gen5. They are required for communication with CR from Android. Also, added some additional changes that are required to align with the current product implementation and simplify the build for Android.